### PR TITLE
Use https protocol for the sphinx-theme submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/_themes"]
 	path = docs/_themes
-	url = git@github.com:rootpy/rootpy-sphinx-theme
+	url = https://github.com/rootpy/rootpy-sphinx-theme.git


### PR DESCRIPTION
This change makes it so "git clone --recursive" will work even if the user does not have a github account + public key set up.
