### PR TITLE
Protect against AttributeError in case of Canvas.Divide

### DIFF
--- a/rootpy/plotting/core.py
+++ b/rootpy/plotting/core.py
@@ -7,7 +7,6 @@ from .style import Color, LineStyle, FillStyle, MarkerStyle
 from .canvas import Canvas
 from .. import rootpy_globals as _globals
 
-
 def dim(hist):
 
     if hasattr(hist, "__dim__"):
@@ -354,8 +353,9 @@ class Plottable(object):
             _globals.pad = Canvas()
         pad = _globals.pad
         pad.cd()
-        if self not in pad.members:
-            pad.members.append(self)
+        if hasattr(pad, 'members'):
+            if self not in pad.members:
+                pad.members.append(self)
         if self.visible:
             if self.format:
                 self.__class__.__bases__[-1].Draw(self,


### PR DESCRIPTION
In case one does a TCanvas.Divide, the object in _globals.pad
can be a TPad, not a rootpy.Pad.  This protects against an AttributeError.

One other possible solution - make 

https://github.com/uwcms/rootpy/pull/new/master#L0L355

return `asrootpy(_globals.pad)`.  However, when I tried to import 
asrootpy from ..utils, there is a circular import.
