### PR TITLE
Bugfix in matplotlist.hist 

### DIFF
--- a/rootpy/plotting/root2matplotlib.py
+++ b/rootpy/plotting/root2matplotlib.py
@@ -152,7 +152,7 @@ def hist(hists, stacked=True, reverse=False, axes=None,
             # Plot the fill with no edge.
             returns.append(_hist(hsum, **kwargs))
             # Plot the edge with no fill.
-            axes.hist(hsum.x, weights=hsum, bins=hsum.xedges(),
+            axes.hist(list(hsum.x()), weights=hsum, bins=list(hsum.xedges()),
                       histtype='step', edgecolor=hsum.GetLineColor())
         _set_bounds(sum(hists), axes=axes, was_empty=was_empty,
                     xpadding=xpadding, ypadding=ypadding,


### PR DESCRIPTION
There was a little bug preventing the plotting of hist objects.
The fixed seemed straight forward looking at _hist
