### PR TITLE
pip installing git rootpy on python 2.6 tries to install python-3?!

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,9 @@ import os
 from os.path import join
 import sys
 
+if sys.version_info < (2, 6):
+    raise RuntimeError("rootpy only supports python 2.6 and above")
+
 local_path = os.path.dirname(os.path.abspath(__file__))
 # setup.py can be called from outside the rootpy directory
 os.chdir(local_path)


### PR DESCRIPTION
I just updated pip and distribute to make sure it wasn't something weird with those..

It's SLC 6.3, python 2.6, pip 1.2.1 and distribute 0.6.30.

This is a curious one.

```
$ pip install -U git+git://github.com/rootpy/rootpy.git#egg=rootpy
Downloading/unpacking rootpy from git+git://github.com/rootpy/rootpy.git#egg=rootpy
  Cloning git://github.com/rootpy/rootpy.git to ./env-slc6/build/rootpy
Cloning into docs/_themes/sphinx-bootstrap...
remote: Counting objects: 104, done.
remote: Compressing objects: 100% (84/84), done.
remote: Total 104 (delta 37), reused 87 (delta 20)
Receiving objects: 100% (104/104), 143.03 KiB, done.
Resolving deltas: 100% (37/37), done.
  Running setup.py egg_info for package rootpy

                     _
     _ __ ___   ___ | |_ _ __  _   _
    | '__/ _ \ / _ \| __| '_ \| | | |
    | | | (_) | (_) | |_| |_) | |_| |
    |_|  \___/ \___/ \__| .__/ \__, |
                        |_|    |___/
          dev

    warning: no files found matching '*' under directory 'doc'
    warning: no files found matching '*.c' under directory 'rootpy'
Downloading/unpacking python>=2.6 from http://www.python.org/ftp/python/3.3.0/Python-3.3.0.tar.bz2 (from rootpy)
  Downloading Python-3.3.0.tar.bz2 (13.8MB): 13.8MB downloaded
  Running setup.py egg_info for package python
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/user1/pwaller/env-slc6/build/python/setup.py", line 1804
        exec(f.read(), globals(), fficonfig)
    SyntaxError: unqualified exec is not allowed in function 'configure_ctypes' it contains a nested function with free variables
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/user1/pwaller/env-slc6/build/python/setup.py", line 1804

    exec(f.read(), globals(), fficonfig)

SyntaxError: unqualified exec is not allowed in function 'configure_ctypes' it contains a nested function with free variables
```
