### PR TITLE
Emit an error wherever the diaper pattern is used

### DIFF
--- a/rootpy/__init__.py
+++ b/rootpy/__init__.py
@@ -183,4 +183,9 @@ def create(cls_name, *args, **kwargs):
         obj = cls(*args, **kwargs)
         return asrootpy(obj)
     except:
+        # TODO: Don't try/except here at all, but use getattr(a, b, None) and
+        #        check for "is None", etc.
+        exc_type, _, _ = sys.exc_info()
+        log.error("BUG: overly broad exception catch. "
+                  "Please report this: '{0}'".format(exc_type))
         return None

--- a/rootpy/networking/network.py
+++ b/rootpy/networking/network.py
@@ -1,5 +1,5 @@
 import socket
-
+from .. import log; log = log[__name__]
 
 def my_ip():
 
@@ -18,6 +18,9 @@ def scan(subnet='192.168.1', port=50000):
             s.connect((addr, port))
             yield addr
         except:
+            exc_type, _, _ = sys.exc_info()
+            log.error("BUG: overly broad exception catch. "
+                      "Please report this: '{0}'".format(exc_type))
             pass
     s.close()
 

--- a/rootpy/plotting/__init__.py
+++ b/rootpy/plotting/__init__.py
@@ -5,7 +5,7 @@ from .hist import Hist, Hist2D, Hist3D, HistStack
 # Exists only in ROOT >=5.28
 try:
     from .hist import Efficiency
-except:
+except ImportError:
     pass
 from .graph import Graph, Graph2D
 from .legend import Legend

--- a/rootpy/plotting/graph.py
+++ b/rootpy/plotting/graph.py
@@ -1,8 +1,12 @@
+import math
+
+from operator import add, sub
+
 import ROOT
+
+from .. import log; log = log[__name__]
 from ..core import NamelessConstructorObject, snake_case_methods, isbasictype
 from .core import Plottable
-from operator import add, sub
-import math
 
 
 @snake_case_methods
@@ -34,6 +38,9 @@ class Graph(Plottable, NamelessConstructorObject, ROOT.TGraphAsymmErrors):
                     self.SetPoint(pointIndex, X, Y)
                     pointIndex += 1
                 except:
+                    exc_type, _, _ = sys.exc_info()
+                    log.error("BUG: overly broad exception catch. "
+                              "Please report this: '{0}'".format(exc_type))
                     pass
             self.Set(pointIndex)
         else:

--- a/rootpy/tree/cut.py
+++ b/rootpy/tree/cut.py
@@ -1,5 +1,8 @@
 import re
+
 import ROOT
+
+from .. import log; log = log[__name__]
 from .. import path
 
 
@@ -75,10 +78,14 @@ class Cut(ROOT.TCut):
             return Cut(thing)
         elif thing is None:
             return Cut()
+            
         try:
             cut = str(thing)
             return Cut(cut)
         except:
+            exc_type, _, _ = sys.exc_info()
+            log.error("BUG: overly broad exception catch. "
+                      "Please report this: '{0}'".format(exc_type))
             raise TypeError("cannot convert %s to Cut" % type(thing))
 
     @property

--- a/rootpy/tree/model.py
+++ b/rootpy/tree/model.py
@@ -4,6 +4,8 @@ import types
 
 import ROOT
 
+from .. import log; log = log["__name__"]
+
 from ..types import Column
 from .buffer import TreeBuffer
 
@@ -128,6 +130,13 @@ class TreeModelMeta(type):
             exec 'from ROOT import %s; struct = %s' % (name, name)
             return struct  # @UndefinedVariable
         except:
+            exc_type, _, _ = sys.exc_info()
+            log.error("BUG: overly broad exception catch. "
+                      "Please report this: '{0}'".format(exc_type))
+            # Note: http://docs.python.org/2/library/exceptions.html#exception-hierarchy
+            # This will catch _everything_, including SystemExit and KeyboardInterrupt,
+            # which is bad. Instead of "returning", I've made it re-raise so we can identify what
+            # the exception should really be.
             return None
 
     def __repr__(cls):

--- a/rootpy/tree/tree.py
+++ b/rootpy/tree/tree.py
@@ -8,6 +8,7 @@ from ..types import Variable
 from ..core import Object, snake_case_methods, RequireFile
 from ..plotting.core import Plottable
 from ..plotting import Hist, Canvas
+from .. import log; log = log["__name__"]
 from .. import asrootpy
 from .. import rootpy_globals as _globals
 from .treeobject import TreeCollection, TreeObject
@@ -491,7 +492,11 @@ class Tree(Object, Plottable, RequireFile, ROOT.TTree):
                 try:
                     hist.decorate(**kwargs)
                 except:
+                    exc_type, _, _ = sys.exc_info()
+                    log.error("BUG: overly broad exception catch. "
+                              "Please report this: '{0}'".format(exc_type))
                     pass
+                    
             if 'goff' not in options:
                 pad.Modified()
                 pad.Update()

--- a/rootpy/types.py
+++ b/rootpy/types.py
@@ -881,6 +881,7 @@ def convert(origin, target, type):
         _origin = numpy_codes
     else:
         raise ValueError("%s is not a valid type" % origin)
+    
     _target = target.upper()
     if _target == 'ROOTCODE':
         _target = root_type_codes
@@ -892,8 +893,8 @@ def convert(origin, target, type):
         _target = numpy_codes
     else:
         raise ValueError("%s is not a valid type" % target)
-    try:
-        index = _origin.index(type)
-    except:
+    
+    if type not in _origin:
         raise ValueError("%s is not a valid %s type" % (type, origin))
+        
     return _target[index]


### PR DESCRIPTION
I think that overbroad exceptions should be considered severe bugs, since
they lead to crazy debugging headaches. I speak from experience.

It's bad practice in python to catch exceptions you're not explicitly 
expecting. Python's mantra "It's easier to ask forgiveness and permission" 
doesn't apply to thinks you weren't intending to do.

```
try:
   ...
except:
    pass
```

will prevent python from exiting, and silence errors you weren't aware of 
anywhere upstream, making it much harder to debug programs.

The same applies with this:

```
try:
    from mod import stuff
except ImportError:
    pass
```

Unfortunately the above is also a bad idea, because it might catch things you
weren't expecting, such as one of `mod`'s imports failing. It is better to
have mod set another variable (`have_stuff`?) than to catch more than you
intended to.

This stuff leads to debugging nightmares, so I've put in an error message at
a few points with the text "BUG: please report this! (exception type)", so
that the correct exception type can be used.

IMHO, it's better to ask permission where it's easily possible.
