### PR TITLE
SetBatch(True) in rootpy.batch

### DIFF
--- a/rootpy/batch/__init__.py
+++ b/rootpy/batch/__init__.py
@@ -1,4 +1,7 @@
 from .. import log; log = log[__name__]
 
+import ROOT
+ROOT.gROOT.SetBatch(True)
+
 from .student import Student
 from .supervisor import Supervisor


### PR DESCRIPTION
Otherwise, with the new rootpy error handler, an error is emitted in a noninteractive environment (grid job) even when importing TCanvas:

https://gist.github.com/4165635

Relevant lines in gui/gui/src/TGClient.cxx:

``` C++
117    // Open the connection to the display                                        
118    if ((fXfd = gVirtualX->OpenDisplay(dpyName)) < 0) {                          
119       Error("TGClient", "can't open display \"%s\", switching to batch mode...\n In case you run from a remote ssh session, reconnect with ssh -Y",
120             gVirtualX->DisplayName(dpyName));                                   
121       MakeZombie();                                                             
122       return;                                                                   
123    }
```
