### PR TITLE
AttributeError: 'module' object has no attribute 'TVector2' in lookup_by_name

### DIFF
--- a/rootpy/__init__.py
+++ b/rootpy/__init__.py
@@ -83,8 +83,8 @@ INIT_REGISTRY = {
 
     'THStack': 'plotting.hist.HistStack',
 
-    'TVector2': 'math.physics.vector.TVector2',
-    'TVector3': 'math.physics.vector.TVector3',
+    'TVector2': 'math.physics.vector.Vector2',
+    'TVector3': 'math.physics.vector.Vector3',
     'TLorentzVector': 'math.physics.vector.LorentzVector',
     'TRotation': 'math.physics.vector.Rotation',
     'TLorentzRotation': 'math.physics.vector.LorentzRotation',


### PR DESCRIPTION
``` python
>>> t.create_buffer()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/cluster/data10/endw/.local/lib/python2.7/site-packages/rootpy-dev-py2.7-linux-x86_64.egg/rootpy/tree/tree.py", line 157, in create_buffer
    ignore_unsupported=ignore_unsupported))
  File "/cluster/data10/endw/.local/lib/python2.7/site-packages/rootpy-dev-py2.7-linux-x86_64.egg/rootpy/tree/buffer.py", line 33, in __init__
    self.__process(branches)
  File "/cluster/data10/endw/.local/lib/python2.7/site-packages/rootpy-dev-py2.7-linux-x86_64.egg/rootpy/tree/buffer.py", line 75, in __process
    cls = lookup_by_name(vtype)
  File "/cluster/data10/endw/.local/lib/python2.7/site-packages/rootpy-dev-py2.7-linux-x86_64.egg/rootpy/__init__.py", line 150, in lookup_by_name
    rootpy_cls = getattr(rootpy_module, rootpy_cls_name)
AttributeError: 'module' object has no attribute 'TVector2'
```
