### PR TITLE
root2hdf5: optional user-defined function to process input tree before conversion to PyTables

### DIFF
--- a/rootpy/io/file.py
+++ b/rootpy/io/file.py
@@ -204,18 +204,18 @@ class TemporaryFile(File, QROOT.TFile):
 
     def __init__(self, *args, **kwargs):
 
-        self.__fd, path = tempfile.mkstemp(*args, **kwargs)
-        super(TemporaryFile, self).__init__(path, 'recreate')
+        self.__fd, self.__tmp_path = tempfile.mkstemp(*args, **kwargs)
+        super(TemporaryFile, self).__init__(self.__tmp_path, 'recreate')
 
     def Close(self):
 
         super(TemporaryFile, self).Close()
         os.close(self.__fd)
+        os.remove(self.__tmp_path)
 
     def __exit__(self, type, value, traceback):
 
         self.Close()
-        os.unlink(self.GetName())
         return False
 
 


### PR DESCRIPTION
I needed to split each tree in half by entry index. Now root2hdf5 has a new optional "script" parameter:

```
usage: root2hdf5 [-h] [-n ENTRIES] [-f] [--ext EXT] [-c {0,1,2,3,4,5,6,7,8,9}]
                 [-l {zlib,lzo,bzip2,blosc}] [--script SCRIPT] [-q]
                 files [files ...]

positional arguments:
  files

optional arguments:
  -h, --help            show this help message and exit
  -n ENTRIES, --entries ENTRIES
                        number of entries to read at once (default: 100000.0)
  -f, --force           overwrite existing output files (default: False)
  --ext EXT             output file extension (default: h5)
  -c {0,1,2,3,4,5,6,7,8,9}, --complevel {0,1,2,3,4,5,6,7,8,9}
                        compression level (default: 5)
  -l {zlib,lzo,bzip2,blosc}, --complib {zlib,lzo,bzip2,blosc}
                        compression algorithm (default: zlib)
  --script SCRIPT       Python script containing a function with the same name 
                        that will be called on each tree and must return a tree or 
                        list of trees that will be converted instead of the 
                        original tree (default: None)
  -q, --quiet           suppress all warnings (default: False)
```

treesplit.py

``` python
def treesplit(tree):
    """ 
    Split input tree in half and return two output trees
    """
    tree1 = tree.CopyTree('Entry$%2==0')
    tree1.SetName('%s_0' % tree.GetName())
    tree2 = tree.CopyTree('Entry$%2==1')
    tree2.SetName('%s_1' % tree.GetName())
    return [tree1, tree2]
```

TemporaryFile is also os.removed when Close() is called.
