### PR TITLE
WIP: Switch travis-ci build to 64 bit ROOT binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,9 @@ script:
 
   # Give user write access to shared memory to make multiprocessing semaphares work 
   # https://github.com/rootpy/rootpy/pull/176#issuecomment-13712313
-  - sudo chmod a+w /dev/shm
+  - ls -la /dev/shm
+  - sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm
+  #- sudo chmod a+w /dev/shm
   - ls -la /dev/shm
 
   # Now run the actual tests (from the installed version, not the local build dir)


### PR DESCRIPTION
Travis recently switched the Python VMs from 32 bit to 64 bit:
https://groups.google.com/d/msg/travis-ci/6XGJ6Jw628k/ppujf6zNLs0J
causing the `rootpy` build to fail.

Here we switch to 64 bit ROOT binaries to make it work again.
