### PR TITLE
add File to registry

### DIFF
--- a/rootpy/__init__.py
+++ b/rootpy/__init__.py
@@ -55,6 +55,7 @@ INIT_REGISTRY = {
     'TTree': 'tree.tree.Tree',
 
     'TDirectoryFile': 'io.file.Directory',
+    'TFile': 'io.file.File',
 
     'TStyle': 'plotting.style.Style',
     'TCanvas': 'plotting.canvas.Canvas',


### PR DESCRIPTION
Although this should rarely be needed assuming the user usually uses rootpy.io.open or rootpy.io.File instead of TFile directly.
