### PR TITLE
minor edit in rootpy browse script options

### DIFF
--- a/scripts/rootpy
+++ b/scripts/rootpy
@@ -355,10 +355,10 @@ def browse(args):
         wait_for_browser_close(browser)
 
 parser_browse = subparsers.add_parser('browse')
-parser_browse.add_argument('-I', '--no-ipython', action='store_false',
-    help="don't try to start ipython", dest="ipython")
-parser_browse.add_argument('-B', '--no-browser', action='store_false',
-    help="don't try to start ipython", dest="browser")
+parser_browse.add_argument('-i', '--no-ipython', action='store_false',
+    help="don't try to start ipython", dest='ipython', default=True)
+parser_browse.add_argument('-b', '--no-browser', action='store_false',
+    help="don't try to start a browser", dest='browser', default=True)
 parser_browse.add_argument('file', nargs="+")
 parser_browse.set_defaults(op=browse)
 


### PR DESCRIPTION
```
rootpy browse --help
usage: rootpy browse [-h] [-i] [-b] file [file ...]

positional arguments:
  file

optional arguments:
  -h, --help        show this help message and exit
  -i, --no-ipython  don't try to start ipython
  -b, --no-browser  don't try to start a browser
```
