### PR TITLE
MRG: matplotlib example fix-ups and error bar colour

### DIFF
--- a/examples/plotting/plot_matplotlib_hist.py
+++ b/examples/plotting/plot_matplotlib_hist.py
@@ -19,24 +19,25 @@ import rootpy.plotting.root2matplotlib as rplt
 import matplotlib.pyplot as plt
 from matplotlib.ticker import AutoMinorLocator
 
-# create normal distributions
-mu1, mu2, sigma1, sigma2 = 100, 140, 15, 5
-x1 = mu1 + sigma1 * np.random.randn(1000)
-x2 = mu2 + sigma2 * np.random.randn(100)
-x1_obs = mu1 + sigma1 * np.random.randn(1000)
-x2_obs = mu2 + sigma2 * np.random.randn(100)
+# set the random seed
+ROOT.gRandom.SetSeed(42)
+np.random.seed(42)
+
+# signal distribution
+signal = 126 + 10 * np.random.randn(100)
+signal_obs = 126 + 10 * np.random.randn(100)
 
 # create histograms
-h1 = Hist(50, 40, 200, title='Background', markersize=0)
+h1 = Hist(30, 40, 200, title='Background', markersize=0)
 h2 = h1.Clone(title='Signal')
 h3 = h1.Clone(title='Data')
 h3.markersize = 1.2
 
 # fill the histograms with our distributions
-map(h1.Fill, x1)
-map(h2.Fill, x2)
-map(h3.Fill, x1_obs)
-map(h3.Fill, x2_obs)
+h1.FillRandom('landau', 1000)
+map(h2.Fill, signal)
+h3.FillRandom('landau', 1000)
+map(h3.Fill, signal_obs)
 
 # set visual attributes
 h1.fillstyle = 'solid'

--- a/rootpy/plotting/root2matplotlib.py
+++ b/rootpy/plotting/root2matplotlib.py
@@ -39,7 +39,7 @@ def _set_defaults(h, kwargs, types=['common']):
                 defaults['hatch'] = h.GetFillStyle('mpl')
         elif key == 'errors':
             defaults['ecolor'] = h.GetLineColor('mpl')
-            defaults['color'] = h.GetMarkerColor('mpl')
+        elif key == 'errorbar':
             defaults['fmt'] = h.GetMarkerStyle('mpl')
         elif key == 'marker':
             defaults['marker'] = h.GetMarkerStyle('mpl')
@@ -315,7 +315,7 @@ def _bar(h, roffset=0., rwidth=1., xerr=None, yerr=None, axes=None, **kwargs):
         xerr = np.array([list(h.xerrl()), list(h.xerrh())])
     if yerr:
         yerr = np.array([list(h.yerrl()), list(h.yerrh())])
-    _set_defaults(h, kwargs, ['common', 'fill'])
+    _set_defaults(h, kwargs, ['common', 'fill', 'errors'])
     width = [x * rwidth for x in h.xwidth()]
     left = [h.xedgesl(i) + h.xwidth(i) * roffset for i in range(len(h))]
     height = h
@@ -369,7 +369,7 @@ def _errorbar(h, xerr, yerr, axes=None, emptybins=True, **kwargs):
 
     if axes is None:
         axes = plt.gca()
-    _set_defaults(h, kwargs, ['common', 'errors', 'marker'])
+    _set_defaults(h, kwargs, ['common', 'errors', 'errorbar', 'marker'])
     if xerr:
         xerr = np.array([list(h.xerrl()), list(h.xerrh())])
     if yerr:


### PR DESCRIPTION
Which one is ROOT?

![matplotlib](https://f.cloud.github.com/assets/202816/183684/d7c8d2e8-7cac-11e2-86c8-72176666a586.png)

![ROOT](https://f.cloud.github.com/assets/202816/183679/9eec1f48-7cac-11e2-8f14-a01c3552efdc.png)
## Known Issues
- ROOT does not show error bar caps when stacking.
- ROOT does not show error bars on the markers in legends.
- ROOT and matplotlib don't play nice with each other. TCanvas locks up while a matplotlib canvas is open.
