### PR TITLE
travis: Do apt-get update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ install:
   # Use system python, not virtualenv, because building the dependencies from source takes too long
   - deactivate # the virtualenv
 
+  # Needed because sometimes travis' repositories get out of date
+  - time sudo apt-get update -qq
+
   # Install the dependencies we need
   - time sudo apt-get install -qq python${PYTHON_SUFFIX}-numpy python${PYTHON_SUFFIX}-sphinx python${PYTHON_SUFFIX}-nose
   # matplotlib and PyTables are not available for Python 3 as packages from the main repo yet.


### PR DESCRIPTION
Travis is currently failing because apt's repositories on travis are
out of date, and apt-get install fails.
