### PR TITLE
Small fix in comments

### DIFF
--- a/examples/tree/chain_overwrite.py
+++ b/examples/tree/chain_overwrite.py
@@ -61,7 +61,7 @@ f_copy = ropen("test_copy.root", "recreate")
 tree_copy = Tree("test_copy")
 
 # If the original tree was not handed to you through rootpy don't forget to:
-# >>> from rootpy.utils import asrootpy
+# >>> from rootpy import asrootpy
 # >>> tree = asrootpy(tree)
 
 # Here we specify the buffer for the new tree to use. We use the same buffer as

--- a/examples/tree/overwrite.py
+++ b/examples/tree/overwrite.py
@@ -54,7 +54,7 @@ f_copy = ropen("test_copy.root", "recreate")
 tree_copy = Tree("test_copy")
 
 # If the original tree was not handed to you through rootpy don't forget to:
-# >>> from rootpy.utils import asrootpy
+# >>> from rootpy import asrootpy
 # >>> tree = asrootpy(tree)
 
 # Here we specify the buffer for the new tree to use. We use the same buffer as


### PR DESCRIPTION
While updating the examples for our analysis I came across outdated comments in rootpy.

'from rootpy.utils import asrootpy' -> 'from rootpy import asrootpy'
Now it is consistent with the changes to rootpy.
