### PR TITLE
list/tuple/array duck typing in hist constructor

### DIFF
--- a/rootpy/plotting/hist.py
+++ b/rootpy/plotting/hist.py
@@ -37,7 +37,7 @@ class _HistBase(Plottable, Object):
         for param in params:
             if len(args) == 0:
                 raise TypeError("Did not receive expected number of arguments")
-            if type(args[0]) in [tuple, list]:
+            if hasattr(args[0], '__iter__'):
                 if list(sorted(args[0])) != list(args[0]):
                     raise ValueError(
                         "Bin edges must be sorted in ascending order")


### PR DESCRIPTION
This fixes rootpy/rootpy#224

Check for `hasattr(arg, '__iter__')` instead of `isinstance(arg, (list, tuple))`. Now histogram constructors accept numpy arrays.
