### PR TITLE
MRG: respect style's default canvas dimensions in Canvas.__init__

### DIFF
--- a/rootpy/defaults.py
+++ b/rootpy/defaults.py
@@ -141,6 +141,3 @@ if hasattr(ROOT.__class__, "_ModuleFacade__finalSetup"):
 else:
     initialized = True
     configure_defaults()
-
-CANVAS_HEIGHT = 500
-CANVAS_WIDTH = 700

--- a/rootpy/plotting/canvas.py
+++ b/rootpy/plotting/canvas.py
@@ -8,7 +8,7 @@ and extend the functionality of the ROOT canvas classes.
 import ROOT
 
 from ..core import Object
-from .. import defaults, QROOT
+from .. import QROOT
 
 
 class _PadBase(Object):


### PR DESCRIPTION
Fixes issue discovered in rootpy/rootpy#231
