### PR TITLE
MRG: Fix ATLAS_label

### DIFF
--- a/rootpy/plotting/style/atlas/labels.py
+++ b/rootpy/plotting/style/atlas/labels.py
@@ -1,32 +1,36 @@
 # Copyright 2012 the rootpy developers
 # distributed under the terms of the GNU General Public License
 import ROOT
+from ....context import preserve_current_canvas
+from ....memory.keepalive import keepalive
 
 
-def ATLAS_label(x, y, text=None, color=1, pad=None):
+def ATLAS_label(x, y, text="Preliminary 20XX", sqrts=8, pad=None):
 
-    l = ROOT.TLatex() #l.SetTextAlign(12); l.SetTextSize(tsize)
-    l.SetNDC()
-    l.SetTextFont(72)
-    l.SetTextColor(color)
     if pad is None:
-        pad = ROOT.pPad
-    delx = 0.115 * 696 * pad.GetWh() / (472 * pad.GetWw())
-    l.DrawLatex(x, y, "ATLAS")
-    if text is not None:
-        p = ROOT.TLatex()
-        p.SetNDC()
-        p.SetTextFont(42)
-        p.SetTextColor(color)
-        p.DrawLatex(x + delx, y, text)
-        #p.DrawLatex(x,y,"#sqrt{s}=900GeV")
-
-def ATLAS_version(version, x=0.88, y=0.975, color=1, pad=None):
-
-    l = ROOT.TLatex()
-    l.SetTextAlign(22)
-    l.SetTextSize(0.04)
-    l.SetNDC()
-    l.SetTextFont(72)
-    l.SetTextColor(color)
-    l.DrawLatex(x, y, "Version %s" % version)
+        pad = ROOT.gPad.func()
+    with preserve_current_canvas():
+        pad.cd()
+        l = ROOT.TLatex()
+        #l.SetTextAlign(12)
+        #l.SetTextSize(tsize)
+        l.SetNDC()
+        l.SetTextFont(72)
+        l.SetTextColor(1)
+        delx = 0.115 * 696 * pad.GetWh() / (472 * pad.GetWw())
+        l.DrawLatex(x, y, "ATLAS")
+        keepalive(pad, l)
+        if text is not None:
+            p = ROOT.TLatex()
+            p.SetNDC()
+            p.SetTextFont(42)
+            p.SetTextColor(1)
+            if sqrts is not None:
+                text = text + " #sqrt{s}=%iTeV" % sqrts
+            p.DrawLatex(x + delx, y, text)
+            keepalive(pad, p)
+        else:
+            p = None
+        pad.Modified()
+        pad.Update()
+    return l, p

--- a/rootpy/plotting/style/atlas/test.py
+++ b/rootpy/plotting/style/atlas/test.py
@@ -3,6 +3,7 @@
 import ROOT
 from rootpy.plotting import Hist
 from rootpy.plotting.style import get_style
+from rootpy.plotting.style.atlas.labels import ATLAS_label
 
 
 def test_atlas():
@@ -15,8 +16,10 @@ def test_atlas():
             hpx.Fill(ROOT.gRandom.Gaus())
         hpx.GetXaxis().SetTitle("random variable [unit]")
         hpx.GetYaxis().SetTitle("#frac{dN}{dr} [unit^{-1}]")
-        hpx.SetMaximum(100.)
+        hpx.SetMaximum(80.)
         hpx.Draw()
+        ATLAS_label(.4, .8)
+
 
 if __name__ == "__main__":
     import nose


### PR DESCRIPTION
``` python
import ROOT
from rootpy.plotting import Hist
from rootpy.plotting.style import set_style
from rootpy.plotting.style.atlas.labels import ATLAS_label
from rootpy.interactive import wait

set_style('ATLAS')
hpx = Hist(100, -4, 4, name="hpx", title="This is the px distribution")
ROOT.gRandom.SetSeed()
for i in xrange(100000):
    hpx.Fill(ROOT.gRandom.Gaus())
hpx.GetXaxis().SetTitle("random variable [unit]")
hpx.GetYaxis().SetTitle("#frac{dN}{dr} [unit^{-1}]")
hpx.SetMaximum(5000)
hpx.Draw()
ATLAS_label(.4, .8, text="Preliminary 2016", sqrts=14)
wait()
```

![c4c896e994f24a4687bc40b9a99baa24](https://f.cloud.github.com/assets/202816/318320/4a6fc59c-9894-11e2-9aee-3a08cebdd52a.png)
