### PR TITLE
Consistenty use root_open, not ropen

### DIFF
--- a/benchmarks/tree/io/tree_read.py
+++ b/benchmarks/tree/io/tree_read.py
@@ -2,7 +2,7 @@
 
 # this import is required to register the Tree class
 import rootpy.tree
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 from time import time
 from ROOT import TTreeCache
 import sys
@@ -10,7 +10,7 @@ import sys
 for cached in (False, True):
 
     try:
-        f = ropen("test.root")
+        f = root_open("test.root")
     except IOError:
         sys.exit("test.root does not exist. Please run tree_write.py first.")
     tree = f.test

--- a/benchmarks/tree/io/tree_write.py
+++ b/benchmarks/tree/io/tree_write.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 from rootpy.tree import Tree, TreeModel
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 from rootpy.types import FloatCol, ObjectCol
 from rootpy.math.physics.vector import LorentzVector
 from random import gauss, randint
 import ROOT
 
-f = ropen("test.root", "recreate")
+f = root_open("test.root", "recreate")
 
 
 # define the model

--- a/benchmarks/tree/root2array/create_tree.py
+++ b/benchmarks/tree/root2array/create_tree.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from rootpy.tree import Tree, TreeModel
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 from rootpy.types import FloatCol, IntCol
 from rootpy.math.physics.vector import LorentzVector
 from random import gauss, randint
@@ -9,7 +9,7 @@ import ROOT
 
 
 entries = 1000000
-f = ropen("test.root", "recreate")
+f = root_open("test.root", "recreate")
 
 
 # define the model

--- a/benchmarks/tree/root2array/test.py
+++ b/benchmarks/tree/root2array/test.py
@@ -2,7 +2,7 @@
 
 # this import is required
 import rootpy.tree
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 
 from rootpy.root2array import tree_to_recarray_py, \
                               tree_to_recarray, \
@@ -11,7 +11,7 @@ from rootpy.root2array import tree_to_recarray_py, \
 import cProfile
 import time
 
-with ropen('test.root') as f:
+with root_open('test.root') as f:
 
     tree = f.test
     branches = ["a_x", "a_y", "a_z"]

--- a/benchmarks/tree/root2array/unique.py
+++ b/benchmarks/tree/root2array/unique.py
@@ -3,7 +3,7 @@
 import cProfile
 import time
 import numpy as np
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 from rootpy.root2array import tree_to_ndarray
 from rootpy.plotting import Hist
 # this import is required
@@ -24,7 +24,7 @@ def rootpy(tree):
     return np.unique(tree_to_ndarray(tree, branches=["a_x"]))
 
 
-with ropen('test.root') as f:
+with root_open('test.root') as f:
 
     tree = f.test
     print "Trees has %i entries" % tree.GetEntries()

--- a/bugs/tree/tree_file_assoc.py
+++ b/bugs/tree/tree_file_assoc.py
@@ -1,14 +1,14 @@
 import ROOT
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 from rootpy.tree import Tree
 
-f = ropen("test.root", "recreate")
+f = root_open("test.root", "recreate")
 
 print ROOT.gDirectory.GetName()
 
 t = Tree()
 
-f2 = ropen("test2.root", "recreate")
+f2 = root_open("test2.root", "recreate")
 f2.Close()
 
 print ROOT.gDirectory.GetName()

--- a/examples/array/tree_to_array.py
+++ b/examples/array/tree_to_array.py
@@ -11,12 +11,12 @@ print __doc__
 import rootpy
 rootpy.log.basic_config_colorized()
 from rootpy.tree import Tree, TreeModel
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 from rootpy.types import FloatCol, IntCol
 from random import gauss
 
 
-f = ropen("test.root", "recreate")
+f = root_open("test.root", "recreate")
 
 
 # define the model

--- a/examples/io/file.py
+++ b/examples/io/file.py
@@ -11,13 +11,13 @@ import os
 import shutil
 import rootpy
 rootpy.log.basic_config_colorized()
-from rootpy.io import root_open as ropen, DoesNotExist
+from rootpy.io import root_open, DoesNotExist
 from rootpy.plotting import Hist, Hist2D
 from rootpy import testdata
 from rootpy import asrootpy
 
 shutil.copyfile(testdata.get_filepath('test_file_2.root'), 'data.root')
-f = ropen('data.root')
+f = root_open('data.root')
 
 print f.a
 print f.a.b
@@ -33,7 +33,7 @@ for thing in f.walk():
 f.close()
 
 # supports with statements
-with ropen('data.root', 'update') as f:
+with root_open('data.root', 'update') as f:
     print f
 
     # write some histograms
@@ -46,7 +46,7 @@ with ropen('data.root', 'update') as f:
 # file is automatically closed after with statement
 
 # retrieve the histograms previously saved
-with ropen('data.root') as f:
+with root_open('data.root') as f:
 
     h1 = f.h1
     # or h1 = f.Get('h1')

--- a/examples/tree/chain.py
+++ b/examples/tree/chain.py
@@ -11,14 +11,14 @@ print __doc__
 import rootpy
 rootpy.log.basic_config_colorized()
 from random import gauss
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 from rootpy.tree import Tree, TreeChain
 from rootpy.plotting import Hist
 
 # Make two files, each with a Tree called "test"
 
 print "Creating test tree in chaintest1.root"
-f = ropen("chaintest1.root", "recreate")
+f = root_open("chaintest1.root", "recreate")
 
 tree = Tree("test")
 branches = {
@@ -45,7 +45,7 @@ tree.write()
 f.close()
 
 print "Creating test tree in chaintest2.root"
-f = ropen("chaintest2.root", "recreate")
+f = root_open("chaintest2.root", "recreate")
 
 tree = Tree("test")
 tree.create_branches(branches)

--- a/examples/tree/chain_overwrite.py
+++ b/examples/tree/chain_overwrite.py
@@ -11,7 +11,7 @@ print __doc__
 import rootpy
 rootpy.log.basic_config_colorized()
 from rootpy.tree import Tree, TreeModel, TreeChain
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 from rootpy.types import FloatCol, IntCol
 from random import gauss
 
@@ -30,7 +30,7 @@ class Event(TreeModel):
 fnames = ["test_%d.root" % i for i in xrange(10)]
 
 for fname in fnames:
-    with ropen(fname, "recreate") as f:
+    with root_open(fname, "recreate") as f:
 
         tree = Tree("test", model=Event)
 
@@ -53,7 +53,7 @@ chain = TreeChain(name="test", files=fnames)
 
 # Now we want to copy the tree above into a new file while overwriting a branch
 # First create a new file to save the new tree in:
-f_copy = ropen("test_copy.root", "recreate")
+f_copy = root_open("test_copy.root", "recreate")
 
 # You may not know the entire model of the original tree but only the branches
 # you intend to overwrite, so I am not specifying the model=Event below as an

--- a/examples/tree/model.py
+++ b/examples/tree/model.py
@@ -9,14 +9,14 @@ associated to sets of tree branches.
 """
 print __doc__
 from rootpy.tree import Tree, TreeModel
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 from rootpy.types import FloatCol, IntCol
 from rootpy.math.physics.vector import LorentzVector
 from rootpy import stl
 from random import gauss, randint
 
 
-f = ropen("test.root", "recreate")
+f = root_open("test.root", "recreate")
 
 
 # define the model
@@ -72,7 +72,7 @@ for i in xrange(100):
 tree.write()
 
 f.close()
-f = ropen("test.root")
+f = root_open("test.root")
 
 tree = f.test
 

--- a/examples/tree/model_simple.py
+++ b/examples/tree/model_simple.py
@@ -8,12 +8,11 @@ This example demonstrates how to define a simple tree model.
 """
 print __doc__
 from rootpy.tree import Tree, TreeModel
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 from rootpy.types import FloatCol, IntCol
 from random import gauss
 
-f = ropen("test.root", "recreate")
-
+f = root_open("test.root", "recreate")
 
 # define the model
 class Event(TreeModel):

--- a/examples/tree/object_branch.py
+++ b/examples/tree/object_branch.py
@@ -12,13 +12,13 @@ import rootpy
 rootpy.log.basic_config_colorized()
 from rootpy.math.physics.vector import LorentzVector
 from rootpy.tree import Tree, TreeModel
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 from rootpy.types import IntCol
 from rootpy import stl
 from random import gauss
 
 
-f = ropen("test.root", "recreate")
+f = root_open("test.root", "recreate")
 
 # define the model
 class Event(TreeModel):

--- a/examples/tree/overwrite.py
+++ b/examples/tree/overwrite.py
@@ -9,7 +9,7 @@ its branches with new values.
 """
 print __doc__
 from rootpy.tree import Tree, TreeModel
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 from rootpy.types import FloatCol, IntCol
 from random import gauss
 
@@ -26,7 +26,7 @@ class Event(TreeModel):
     i = IntCol()
 
 # first create a tree "test" in a file "test.root"
-f = ropen("test.root", "recreate")
+f = root_open("test.root", "recreate")
 
 tree = Tree("test", model=Event)
 
@@ -46,7 +46,7 @@ branch with new values.
 
 # Now we want to copy the tree above into a new file while overwriting a branch
 # First create a new file to save the new tree in:
-f_copy = ropen("test_copy.root", "recreate")
+f_copy = root_open("test_copy.root", "recreate")
 
 # You may not know the entire model of the original tree but only the branches
 # you intend to overwrite, so I am not specifying the model=Event below as an

--- a/examples/tree/simple.py
+++ b/examples/tree/simple.py
@@ -8,10 +8,10 @@ This example demonstrates how to create a simple tree.
 """
 print __doc__
 from rootpy.tree import Tree
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 from random import gauss
 
-f = ropen("test.root", "recreate")
+f = root_open("test.root", "recreate")
 
 tree = Tree("test")
 tree.create_branches(

--- a/examples/tree/user_object.py
+++ b/examples/tree/user_object.py
@@ -11,7 +11,7 @@ print __doc__
 import rootpy
 rootpy.log.basic_config_colorized()
 from rootpy.tree import Tree, TreeModel
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 from rootpy.types import IntCol, ObjectCol
 import rootpy.compiled as C
 from random import gauss
@@ -37,7 +37,7 @@ class Event(TreeModel):
     thingy = ObjectCol(C.Thingy)
 
 
-f = ropen("test.root", "recreate")
+f = root_open("test.root", "recreate")
 tree = Tree("test", model=Event)
 
 # fill the tree
@@ -52,7 +52,7 @@ tree.write()
 f.close()
 
 # now to read the same tree
-with ropen("test.root") as f:
+with root_open("test.root") as f:
 
     tree = f.test
 

--- a/rootpy/batch/student.py
+++ b/rootpy/batch/student.py
@@ -17,7 +17,7 @@ except AttributeError:
 
 import traceback
 import signal
-from rootpy.io import root_open as ropen
+from rootpy.io import root_open
 import cProfile as profile
 import subprocess
 
@@ -75,7 +75,7 @@ class Student(Process):
 
         try:
             filename = 'student-%s-%s.root' % (self.name, self.uuid)
-            with ropen(os.path.join(
+            with root_open(os.path.join(
                     os.getcwd(), filename), 'recreate') as self.output:
                 ROOT.gROOT.SetBatch(True)
                 if self.queuemode:

--- a/rootpy/batch/supervisor.py
+++ b/rootpy/batch/supervisor.py
@@ -9,7 +9,7 @@ from multiprocessing import Process
 # multiprocessing uses the exceptions from the Queue module
 import Queue
 from ..tree.filtering import FilterList
-from ..io import root_open as ropen
+from ..io import root_open
 from ..plotting import Hist
 
 from ..logger import multilogging
@@ -312,7 +312,7 @@ class Supervisor(Process):
                     os.unlink(output)
             if write_cutflows:
                 # write cut-flow in ROOT file as TH1
-                with ropen(outputname, 'UPDATE'):
+                with root_open(outputname, 'UPDATE'):
                     for name, filterlist in merged_filters.items():
                         cutflow = Hist(
                                 len(filterlist) + 1, .5,

--- a/rootpy/root2hdf5.py
+++ b/rootpy/root2hdf5.py
@@ -9,7 +9,7 @@ import sys
 import tables
 import warnings
 
-from .io import root_open as ropen, utils, TemporaryFile
+from .io import root_open, utils, TemporaryFile
 from . import log; log = log[__name__]
 from .extern.progressbar import ProgressBar, Bar, ETA, Percentage
 from .logger.util import check_tty
@@ -26,7 +26,7 @@ def convert(rfile, hfile, rpath='', entries=-1, userfunc=None, selection=None):
     if isinstance(hfile, basestring):
         hfile = tables.openFile(filename=hfile, mode="w", title="Data")
     if isinstance(rfile, basestring):
-        rfile = ropen(rfile)
+        rfile = root_open(rfile)
 
     for dirpath, dirnames, treenames in utils.walk(
             rfile, rpath, class_pattern='TTree'):
@@ -196,7 +196,7 @@ def main():
             sys.exit(('Output %s already exists. '
                 'Use the --force option to overwrite it') % outputname)
         try:
-            rootfile = ropen(inputname)
+            rootfile = root_open(inputname)
         except IOError:
             sys.exit("Could not open %s" % inputname)
         try:

--- a/rootpy/tree/chain.py
+++ b/rootpy/tree/chain.py
@@ -2,7 +2,7 @@
 # distributed under the terms of the GNU General Public License
 import multiprocessing
 import time
-from ..io import root_open as ropen, DoesNotExist
+from ..io import root_open, DoesNotExist
 from .filtering import EventFilterList
 from ..util.extras import humanize_bytes
 from .. import log; log = log[__name__]
@@ -174,7 +174,7 @@ class _BaseTreeChain(object):
             return False
         try:
             with preserve_current_directory():
-                self._file = ropen(filename)
+                self._file = root_open(filename)
         except IOError:
             self._file = None
             log.warning("could not open file %s (skipping)" % filename)

--- a/rootpy/tree/tests/test_tree.py
+++ b/rootpy/tree/tests/test_tree.py
@@ -2,7 +2,7 @@
 # distributed under the terms of the GNU General Public License
 from rootpy.math.physics.vector import LorentzVector
 from rootpy.tree import Tree, TreeModel, TreeChain
-from rootpy.io import root_open as ropen, TemporaryFile
+from rootpy.io import root_open, TemporaryFile
 from rootpy.types import FloatCol, IntCol
 from rootpy.plotting import Hist, Hist2D, Hist3D
 from rootpy import testdata
@@ -76,7 +76,7 @@ class TreeTests(TestCase):
 
     def test_attrs(self):
 
-        with ropen(self.file_paths[0]) as f:
+        with root_open(self.file_paths[0]) as f:
             tree = f.tree
             tree.read_branches_on_demand(True)
             tree.define_object('a', 'a_')
@@ -92,7 +92,7 @@ class TreeTests(TestCase):
 
     def test_cuts(self):
 
-        with ropen(self.file_paths[0]) as f:
+        with root_open(self.file_paths[0]) as f:
             tree = f.tree
             h1 = Hist(10, -1, 2)
             h2 = Hist2D(10, -1, 2, 10, -1, 2)


### PR DESCRIPTION
At the moment this is used all over the place:

```
from rootpy.io import root_open as ropen
```

If I remember correctly we discussed this briefly in Saas Fee and decided to go with 

```
from rootpy.io import root_open
```

in the rootpy code and docs instead as it is a bit more explicit and doesn't require users to remember such an "import convention".
