### PR TITLE
Fix uninformative exception on File AttributeError

### DIFF
--- a/rootpy/io/file.py
+++ b/rootpy/io/file.py
@@ -91,7 +91,7 @@ class _DirectoryBase(Object):
         # identifier (not a path including subdirectories).
         thing = super(_DirectoryBase, self).Get(attr)
         if not thing:
-            raise AttributeError
+            raise AttributeError("{0} has no attribute '{1}'".format(self, attr))
         thing = asrootpy(thing)
         if isinstance(thing, Directory):
             thing._path = os.path.join(self._path, thing.GetName())


### PR DESCRIPTION
If you tried to access a bad attribute on a file object, you get an
AttributeError with no further information. With this patch, the output
looks like this:

```
AttributeError: File('pdf-components.root') has no attribute 'hpdf_ta__x'
```
