### PR TITLE
Breaking change: Legend.AddEntry -> use same argument order of ROOT

### DIFF
--- a/rootpy/plotting/legend.py
+++ b/rootpy/plotting/legend.py
@@ -64,7 +64,7 @@ class Legend(Object, QROOT.TLegend):
         self.pad.Modified()
         self.pad.Update()
 
-    def AddEntry(self, thing, legendstyle=None, label=None):
+    def AddEntry(self, thing, label=None, legendstyle=None):
         """
         Add an entry to the legend.
 


### PR DESCRIPTION
With reference to [this 
comment](https://github.com/rootpy/rootpy/commit/bbcb64a5f99e00bb73894de81acbaf49e789288b#commitcomment-3372263).

It seems really bad juju to me to change the argument order between rootpy and root. Ideally, one should be able 
to swap out plain-root classes for rootpy ones transparently.

Apologies to any existing code this breaks, but I think it might be worth it going forward.
