### PR TITLE
filter superfluous ROOT warnings

### DIFF
--- a/rootpy/logger/__init__.py
+++ b/rootpy/logger/__init__.py
@@ -142,6 +142,7 @@ def log_trace(logger, level=logging.DEBUG, show_enter=True, show_exit=True):
         return thunk
     return wrap
 
+
 class LogFilter(logging.Filter):
     def __init__(self, logger, message_regex):
         logging.Filter.__init__(self)
@@ -157,3 +158,21 @@ class LogFilter(logging.Filter):
 
     def filter(self, record):
         return not self.message_regex.match(record.getMessage())
+
+
+class LiteralFilter(logging.Filter):
+    def __init__(self, literals):
+        logging.Filter.__init__(self)
+        self.literals = literals
+
+    def filter(self, record):
+        return record.getMessage() not in self.literals
+
+
+# filter superfluous ROOT warnings
+log["/ROOT.TH1D.Add"].addFilter(LiteralFilter(
+    ["Attempt to add histograms with different axis limits",]))
+log["/ROOT.TH1D.Divide"].addFilter(LiteralFilter(
+    ["Attempt to divide histograms with different axis limits",]))
+log["/ROOT.TH1D.Multiply"].addFilter(LiteralFilter(
+    ["Attempt to multiply histograms with different axis limits",]))


### PR DESCRIPTION
``` python
import rootpy  # <== this now silences the warnings that would otherwise be logged below
from ROOT import TH1D, TCanvas

a = TH1D("a", "a", 10, 0, 1)
c1 = TCanvas()
a.Draw()

c2 = TCanvas()
b = a.Clone()
b.Draw()
b.GetYaxis().SetLimits(0, 0.5)

# ROOT, why do you warn me here?
a + b
a.Divide(b)
a * b
a - b
```

```
TH1D::Add:0: RuntimeWarning: Attempt to add histograms with different axis limits
TH1D::Divide:0: RuntimeWarning: Attempt to divide histograms with different axis limits
TH1D::Multiply:0: RuntimeWarning: Attempt to multiply histograms with different axis limits
TH1D::Add:0: RuntimeWarning: Attempt to add histograms with different axis limits
```

https://sft.its.cern.ch/jira/browse/ROOT-5249
