### PR TITLE
`rootpy browse` should change the way it starts ipython

### DIFF
--- a/scripts/rootpy
+++ b/scripts/rootpy
@@ -356,7 +356,7 @@ def browse(args):
                 ROOT.gInterpreter.EndOfLineAction()
             ip.set_hook('pre_prompt_hook', pre_prompt_hook)
             
-            ip()
+            ip(local_ns=globals())
             
             if args.browser and browser:
                 browser.Delete()


### PR DESCRIPTION
The problem is that we have separate local and global namespaces, that means:

``` ipython
In [1]: import re

In [2]: locals()["re"]
Out[2]: <module 're' from '/usr/lib64/python2.6/re.pyc'>

In [3]: globals()["re"]
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
/user1/pwaller/.local/src/rootpy/scripts/rootpy in <module>()
----> 1 globals()["re"]

KeyError: 're'

In [4]: def test(): return re

In [5]: test()
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
/user1/pwaller/.local/src/rootpy/scripts/rootpy in <module>()
----> 1 test()

/user1/pwaller/.local/src/rootpy/scripts/rootpy in test()
----> 1 def test(): return re

NameError: global name 're' is not defined
```

See ipython/ipython#62
