### PR TITLE
`snake_case_methods` breaks descriptors

### DIFF
--- a/rootpy/io/file.py
+++ b/rootpy/io/file.py
@@ -463,7 +463,7 @@ class Directory(_DirectoryBase, QROOT.TDirectoryFile):
 
         return self.__str__()
 
-
+@snake_case_methods
 class _FileBase(_DirectoryBase):
 
     # Override .Open

--- a/rootpy/io/tests/test_file.py
+++ b/rootpy/io/tests/test_file.py
@@ -48,6 +48,9 @@ def test_memfile():
         hist.Write()
         assert_equal(f['test'], hist)
 
+def test_file_open():
+    with MemFile.open("test", "recreate"):
+        pass
 
 def test_file_get():
 

--- a/rootpy/tests/test_decorators.py
+++ b/rootpy/tests/test_decorators.py
@@ -6,7 +6,7 @@ from rootpy.decorators import (method_file_check, method_file_cd,
                                snake_case_methods)
 from rootpy.io import TemporaryFile
 import rootpy
-from nose.tools import assert_true, raises
+from nose.tools import assert_equal, assert_true, raises
 
 
 def test_snake_case_methods():
@@ -30,6 +30,35 @@ def test_snake_case_methods():
     assert_true(hasattr(B, 'write'))
     assert_true(hasattr(B, 'other_method'))
 
+
+def test_snake_case_methods_descriptor():
+
+    def f(_): pass
+
+    class A(object):
+        Prop = property(f)
+        Sm = staticmethod(f)
+        Cm = classmethod(f)
+        M = f
+    
+    class B(A):
+        cm = A.__dict__["Cm"]
+        m = A.__dict__["M"]
+        prop = A.__dict__["Prop"]
+        sm = A.__dict__["Sm"]
+    
+    @snake_case_methods
+    class snakeB(A):
+        pass
+        
+    # Ensure that no accidental descriptor dereferences happened inside
+    # `snake_case_methods`. This is checked by making sure that the types
+    # are the same between B and snakeB.
+    
+    for member in dir(snakeB):
+        if member.startswith("_"): continue
+        assert_equal(type(getattr(B, member)), type(getattr(snakeB, member)))
+        
 
 class Foo(Object, ROOT.TH1D):
 


### PR DESCRIPTION
This bug caused a regression in 01edd2d99feede77e74b3ae87a2c95ed0bdf33dd. Compare the output of this commit and the one beforehand:

```
[01edd2^] $ python -c "import rootpy.ROOT as R; print R.File.open"
<function root_open at 0x14d2488>
[01edd2] $ python -c "import rootpy.ROOT as R; print R.File.open"
<unbound method File.root_open>
```

The latter is not usable and breaks my code.
# What's the problem?

The problem is due to the way that [`snake_case_methods`](https://github.com/rootpy/rootpy/blob/master/rootpy/decorators.py#L155) (SCM) works. I thought I had fixed this in 29626c704158eab8cfcf00963b1627e11b4d04bd, but apparently not.

The root cause is in the way that SCM aliases existing methods. Prior to 29626c7, it did this by `getattr`ing the target function and `setattr`'ing it on the target class. The problem is that `getattr` actually "dereferences" the descriptor (`__get__`) of target function. That means that `staticmethod`s become ordinary functions, which then get tacked onto the target class and suddenly they look like unbound methods.

I tried to fix this by making it a `__dict__` lookup on the target class, which prevents the descriptor machinary from kicking in, but then 01edd2d shows that this isn't sufficient, because of inheritance - the target function might not be in the `cls.__dict__` but in one of its super classes - so we need to visit the super classes in order according to the mro, and look inside the `__dict__` of each one.
# What's needed to prevent this from happening again?

Two test cases:
1. Check that File.open works correctly
2. Check that `snake_case_methods` does the right thing.
