### PR TITLE
rootwait: failover on raw_input if no PyGUIThread

### DIFF
--- a/rootpy/defaults.py
+++ b/rootpy/defaults.py
@@ -123,15 +123,15 @@ if hasattr(ROOT.__class__, "_ModuleFacade__finalSetup"):
     @wraps(finalSetup)
     def wrapFinalSetup(*args, **kwargs):
 
-        log.debug('finalSetup has been triggered')
+        log.debug("PyROOT's finalSetup() has been triggered")
 
         if os.environ.get("ROOTPY_DEBUG", None) and rp_module_level_in_stack():
             # Check to see if we're at module level anywhere in rootpy.
             # If so, that's not ideal.
             l = log["bug"]
             l.showstack()
-            l.debug("finalSetup triggered from rootpy at module-level. "
-                    "Please report this.")
+            l.debug("PyROOT's finalSetup() triggered from rootpy at "
+                    "module-level. Please report this.")
 
         # if running in the ATLAS environment suppress a known harmless warning
         if os.environ.get("AtlasVersion", None):
@@ -141,6 +141,10 @@ if hasattr(ROOT.__class__, "_ModuleFacade__finalSetup"):
                 result = finalSetup(*args, **kwargs)
         else:
             result = finalSetup(*args, **kwargs)
+
+        log.debug(
+            "PyROOT's finalSetup() has been called "
+            "(gROOT.IsBatch()=={0})".format(ROOT.gROOT.IsBatch()))
 
         configure_defaults()
 


### PR DESCRIPTION
This is a solution to #226 

```
    if _processRootEvents is None:                                              
        log.warning(                                                            
            "unable to access ROOT's GUI thread either because "                
            "PyROOT's finalSetup() was called while in batch mode "             
            "or because PyROOT is using the new PyOS_InputHook "                
            "based mechanism that is not yet supported in rootpy "              
            "(PyConfig.StartGuiThread == 'inputhook' or "                       
            "gSystem.InheritsFrom('TMacOSXSystem')). wait() etc. will "         
            "instead call raw_input() and wait for [Enter]")
```

trigger with

```
from rootpy.plotting import Hist
from rootpy.interactive import wait
import ROOT

ROOT.gROOT.SetBatch(True)
# trigger PyROOT's finalSetup()
ROOT.kTRUE
ROOT.gROOT.SetBatch(False)

h = Hist(50, 0, 100)
h.Draw('hist')

wait()
```
