### PR TITLE
[MRG] hist: fix new_binning_template, properly set bins of copied axes

### DIFF
--- a/rootpy/plotting/hist.py
+++ b/rootpy/plotting/hist.py
@@ -729,10 +729,7 @@ class _HistBase(Plottable, NamedObject):
             if iaxis == axis:
                 args.extend(binning)
             else:
-                args.extend([
-                    self.nbins(iaxis),
-                    self._edges(iaxis, 0),
-                    self._edges(iaxis, -1)])
+                args.append(list(self._edges(axis=iaxis)))
         return cls(*args, type=self.TYPE)
 
 


### PR DESCRIPTION
![binmerge2d](https://f.cloud.github.com/assets/202816/1187441/5b6f1c2e-2379-11e3-8a8b-0cb28c1e97fa.gif)

This PR fixes a bug where the bin edges of the unmodified axes in new_binning_template were not set correctly.
