### PR TITLE
[MRG] hist: new rebinned method for all rebinning cases and for all dimensions

### DIFF
--- a/rootpy/plotting/tests/test_hist.py
+++ b/rootpy/plotting/tests/test_hist.py
@@ -124,6 +124,24 @@ def test_merge_bins():
     assert_equal(h3d.GetSumOfWeights(), h3d_merged.GetSumOfWeights())
     assert_equal(h3d_merged.nbins(1), 6)
 
+def test_rebinning():
+
+    h1d = Hist(100, 0, 1)
+    h1d.FillRandom('gaus')
+    assert_equal(h1d.rebinned(2).nbins(0), 50)
+    assert_equal(h1d.rebinned((2,)).nbins(0), 50)
+    assert_equal(h1d.rebinned([0, .5, 1]).nbins(0), 2)
+
+    h3d = Hist3D(10, 0, 1, 10, 0, 1, 10, 0, 1)
+    h3d.FillRandom('gaus')
+    assert_equal(h3d.rebinned(2).nbins(0), 5)
+    new = h3d.rebinned((2, 5, 1))
+    assert_equal(new.nbins(0), 5)
+    assert_equal(new.nbins(1), 2)
+    assert_equal(new.nbins(2), 10)
+    new = h3d.rebinned([0, 5, 10], axis=1)
+    assert_equal(new.nbins(1), 2)
+
 
 if __name__ == "__main__":
     import nose


### PR DESCRIPTION
Flatten a histogram by rebinning with the quantiles, for example:

``` python
>>> from rootpy.plotting import Hist
>>> a = Hist(500, -5, 30)
>>> a.FillRandom('landau', 10000000)
>>> a.Draw()
>>> b = a.rebinned(a.quantiles(10, strict=True))
>>> b.SetMinimum(0)
>>> b.Draw()
```

``` python
    def rebinned(self, bins, axis=0):                                           
        """                                                                     
        Return a new rebinned histogram                                         

        Parameters                                                              
        ----------                                                              

        bins : int, tuple, or iterable                                          
            If ``bins`` is an int, then return a histogram that is rebinned by  
            grouping N=``bins`` bins together along the axis ``axis``.          
            If ``bins`` is a tuple, then it must contain the same number of     
            elements as there are dimensions of this histogram and each element 
            will be used to rebin along the associated axis.                    
            If ``bins`` is another iterable, then it will define the bin        
            edges along the axis ``axis`` in the new rebinned histogram.        

        axis : int, optional (default=0)                                        
            The axis to rebin along.                                            

        Returns                                                                 
        -------                                                                 

        The rebinned histogram                                                  

        """
```
