### PR TITLE
[MRG] New Canvas/Pad properties and add tick_length_pixels

### DIFF
--- a/rootpy/plotting/canvas.py
+++ b/rootpy/plotting/canvas.py
@@ -182,6 +182,14 @@ class Canvas(_PadBase, QROOT.TCanvas):
                                    curr_height + (curr_height - self.GetWh()))
 
     @property
+    def width_pixels(self):
+        return self.GetWw()
+
+    @width_pixels.setter
+    def width_pixels(self, value):
+        self.width = value
+
+    @property
     def height(self):
         return self.GetWh()
 
@@ -195,3 +203,11 @@ class Canvas(_PadBase, QROOT.TCanvas):
             if not getattr(self, 'size_includes_decorations', False):
                 self.SetWindowSize(curr_width + (curr_width - self.GetWw()),
                                    value + (value - self.GetWh()))
+
+    @property
+    def height_pixels(self):
+        return self.GetWh()
+
+    @height_pixels.setter
+    def height_pixels(self, value):
+        self.height = value

--- a/rootpy/plotting/utils.py
+++ b/rootpy/plotting/utils.py
@@ -17,6 +17,7 @@ __all__ = [
     'get_limits',
     'get_band',
     'canvases_with',
+    'tick_length_pixels',
 ]
 
 
@@ -370,3 +371,13 @@ def canvases_with(drawable):
     """
     return [c for c in ROOT.gROOT.GetListOfCanvases()
             if drawable in _PadBase.find_all_primitives(c)]
+
+
+def tick_length_pixels(pad, xaxis, yaxis, xlength, ylength=None):
+    """
+    Set the axes tick lengths in pixels
+    """
+    if ylength is None:
+        ylength = xlength
+    xaxis.SetTickLength(xlength / float(pad.height_pixels))
+    yaxis.SetTickLength(ylength / float(pad.width_pixels))


### PR DESCRIPTION
New pad properties make it easier to get dimensions in pixels and `tick_length_pixels` will set the tick lengths in pixels.
