### PR TITLE
fixing graph division

### DIFF
--- a/rootpy/plotting/graph.py
+++ b/rootpy/plotting/graph.py
@@ -255,7 +255,7 @@ class _Graph1DBase(_GraphBase):
                 lowerror = Graph(len(other))
                 higherror = Graph(len(other))
                 for index, (x, (ylow, yhigh)) in enumerate(
-                        zip(other.x(), other.errorsy())):
+                        zip(other.x(), other.yerr())):
                     lowerror[index] = (x, ylow)
                     higherror[index] = (x, yhigh)
             for index in xrange(len(self)):


### PR DESCRIPTION
As the title says.
For some reason the graph division was using 

```
Graph.errorsy()
```

instead of 

```
Graph.yerr()
```

to get the lower and upper errors.

I hope this fix is OK (it does not work without).

I was also thinking about adding a test for it, but it seems that the test folder is almost empty. Didn't you use to have a quite good test coverage? 

Cheers,
Luke
