### PR TITLE
draw() if graph is the first object, don't use the A option

### DIFF
--- a/examples/plotting/plot_overlay.py
+++ b/examples/plotting/plot_overlay.py
@@ -26,8 +26,10 @@ objects = []
 
 # create a stack
 stack = HistStack()
-stack.Add(Hist(100, -5, 5, color='salmon', drawstyle='hist').FillRandom(F1('TMath::Gaus(x, 2, 1)'), 500))
-stack.Add(Hist(100, -5, 5, color='powderblue', drawstyle='hist').FillRandom(F1('TMath::Gaus(x, 2, 0.6)'), 300))
+stack.Add(Hist(100, -5, 5, color='salmon', drawstyle='hist').FillRandom(
+          F1('TMath::Gaus(x, 2, 1)'), 500))
+stack.Add(Hist(100, -5, 5, color='powderblue', drawstyle='hist').FillRandom(
+          F1('TMath::Gaus(x, 2, 0.6)'), 300))
 objects.append(stack)
 
 # create some random histograms
@@ -43,7 +45,7 @@ for i in xrange(10):
     graph.SetPoint(i, x, 40 + 10 * sin(x))
 objects.append(graph)
 
-draw(objects, xtitle='Some Variable [Units]', ytitle='Events', ypadding=0.05,)
+draw(objects, xtitle='Some Variable [Units]', ytitle='Events', ypadding=0.05)
 # see rootpy.plotting.utils.get_limits for details on what arguments are
 # supported for setting the axes ranges.
 wait()

--- a/rootpy/plotting/utils.py
+++ b/rootpy/plotting/utils.py
@@ -74,35 +74,34 @@ def draw(plottables, pad=None, same=False, xtitle=None, ytitle=None,
     with context():
         if pad is not None:
             pad.cd()
-        # get the axis limits
+        # get the axes limits
         xmin, xmax, ymin, ymax = get_limits(plottables, **kwargs)
         if not same:
             # draw and get the axes with a temporary histogram
             hist = Hist(1, 0, 1)
             hist.Draw('AXIS')
+            # ignore axes from user if any
             xaxis = hist.xaxis
             yaxis = hist.yaxis
         # draw the plottables
         for i, obj in enumerate(plottables):
-            # special case when drawing THStacks...
-            # need to draw again after setting the axis limits
             if i == 0 and isinstance(obj, ROOT.THStack):
                 # use SetMin/Max for y-axis
                 obj.SetMinimum(ymin)
                 obj.SetMaximum(ymax)
-                obj.Draw('SAME' if same else '')
                 # ROOT: please fix this...
-            else:
-                obj.Draw('SAME' if same or i > 0 else '')
-        # set the axis limits
+            obj.Draw('SAME')
+        # set the axes limits and titles
         if xaxis is not None:
             xaxis.SetLimits(xmin, xmax)
             xaxis.SetRangeUser(xmin, xmax)
-            xaxis.SetTitle(xtitle)
+            if xtitle is not None:
+                xaxis.SetTitle(xtitle)
         if yaxis is not None:
             yaxis.SetLimits(ymin, ymax)
             yaxis.SetRangeUser(ymin, ymax)
-            yaxis.SetTitle(ytitle)
+            if ytitle is not None:
+                yaxis.SetTitle(ytitle)
     return (xaxis, yaxis), (xmin, xmax, ymin, ymax)
 
 


### PR DESCRIPTION
The A option draws ugly lines at (0, 0) as well as the axes frame. Instead use a temporary histogram to draw the axes.

ROOT, your graph classes are horrible.
