### PR TITLE
[WIP] rootpy for ROOT 6 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,12 @@ python:
   - "2.7"
   #- "3.2"
 env:
-  #- ROOT=5-32-00
-  #- ROOT=5-32-01
-  #- ROOT=5-32-02
-  #- ROOT=5-32-03
-  - ROOT=5-32-04
-  #- ROOT=5-33-02
-  #- ROOT=5-33-02b
-  #- ROOT=5-34-00
-  #- ROOT=5-34-04
-  #- ROOT=5-34-05
-  #- ROOT=5-34-06
-  #- ROOT=5-34-07
-  - ROOT=5-34-08
-  - ROOT=6-02-04
+  matrix:
+    - ROOT=5-32-04
+    - ROOT=5-34-08
+    - ROOT=6-02-04
+  global:
+    - CLANG_VERSION=3.4
 install: source ci/install.sh
 script: bash ci/test.sh
 cache: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   matrix:
     - ROOT=5-32-04
     - ROOT=5-34-08
-    - ROOT=6-02-04
+    - ROOT=6-00-00
   global:
     - CLANG_VERSION=3.4
 install: source ci/install.sh
@@ -18,4 +18,4 @@ cache:
   - apt
   - directories: # also works for files ;)
     - root_v5-34-25_python_2.7.tar.gz
-    - root_v6-02-04_python_2.7.tar.gz
+    - root_v6-00-00_python_2.7.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,11 @@ env:
   #- ROOT=5-34-06
   #- ROOT=5-34-07
   - ROOT=5-34-08
-  #- ROOT=5-99-02
+  - ROOT=6-02-04
 install: source ci/install.sh
 script: bash ci/test.sh
-cache: apt
+cache: 
+	apt
+	directories: # also works for files ;)
+  		- root_v5-34-25_python_2.7.tar.gz
+  		- root_v6-02-04_python_2.7.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
 install: source ci/install.sh
 script: bash ci/test.sh
 cache: 
-	apt
-	directories: # also works for files ;)
-  		- root_v5-34-25_python_2.7.tar.gz
-  		- root_v6-02-04_python_2.7.tar.gz
+  - apt
+  - directories: # also works for files ;)
+    - root_v5-34-25_python_2.7.tar.gz
+    - root_v6-02-04_python_2.7.tar.gz

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -11,13 +11,14 @@ if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then
     export PYTHON_SUFFIX="3"
 fi
 
-# add repositories for gcc 4.8 and clang 3.5
+# add repositories for gcc 4.8 and clang $CLANG_VERSION (set in .travis.yml)
 sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
 sudo add-apt-repository --yes 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main'
 wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+# Needed because sometimes travis' repositories get out of date
 sudo apt-get update -qq
 sudo apt-get install -qq python${PYTHON_SUFFIX}-pip python${PYTHON_SUFFIX}-numpy python${PYTHON_SUFFIX}-sphinx python${PYTHON_SUFFIX}-nose
-sudo apt-get install -qq clang-3.5 libclang-3.5-dev gcc-4.8 g++-4.8
+sudo apt-get install -qq clang-${CLANG_VERSION} libclang-${CLANG_VERSION}-dev gcc-4.8 g++-4.8 libboost-dev
 
 # matplotlib and PyTables are not available for Python 3 as packages from the main repo yet.
 if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -11,13 +11,26 @@ if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then
     export PYTHON_SUFFIX="3"
 fi
 
+# add repositories for gcc 4.8 and clang 3.5
+sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
+sudo add-apt-repository --yes 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main'
+wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt-get update -qq
 sudo apt-get install -qq python${PYTHON_SUFFIX}-pip python${PYTHON_SUFFIX}-numpy python${PYTHON_SUFFIX}-sphinx python${PYTHON_SUFFIX}-nose
+sudo apt-get install -qq clang-3.5 libclang-3.5-dev gcc-4.8 g++-4.8
 
 # matplotlib and PyTables are not available for Python 3 as packages from the main repo yet.
 if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then
     time sudo apt-get install -qq python${PYTHON_SUFFIX}-matplotlib python${PYTHON_SUFFIX}-tables
 fi
+
+if [[ $ROOT == 6* ]]; then
+  sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50;
+  sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50;
+  sudo update-alternatives --set gcc /usr/bin/gcc-4.8;
+  sudo update-alternatives --set g++ /usr/bin/g++-4.8;
+fi
+
 
 pip install uncertainties
 


### PR DESCRIPTION
This is a response to #101. In order for this to work, this file needs to be uploaded to copy.com:
https://kreczko.web.cern.ch/kreczko/root_builds/root_v6.00.00_python_2.7.tar.gz
and renamed to 
root_v6-00-00_python_2.7.tar.gz
This is the compiled ROOT 6 version created using
https://github.com/BristolTopGroup/DailyPythonScripts/wiki/Continuous-Integration