### PR TITLE
Optionally add a color bar to the 2D matplotlib plots created with hist2d and imshow

### DIFF
--- a/rootpy/plotting/root2matplotlib.py
+++ b/rootpy/plotting/root2matplotlib.py
@@ -777,7 +777,7 @@ def imshow(h, axes=None, colorbar=False, **kwargs):
     return axis_image
 
 
-def contour(h, axes=None, zoom=None, contourlabel=False, **kwargs):
+def contour(h, axes=None, zoom=None, label_contour=False, **kwargs):
     """
     Draw a matplotlib contour plot from a 2D ROOT histogram.
 
@@ -796,7 +796,7 @@ def contour(h, axes=None, zoom=None, contourlabel=False, **kwargs):
         The histogram is zoomed using a cubic spline interpolation to create
         smooth contours.
 
-    contourlabel : Boolean, optional (default=False)
+    label_contour : Boolean, optional (default=False)
         If True, labels are printed on the contour lines.
 
     kwargs : additional keyword arguments, optional
@@ -825,6 +825,6 @@ def contour(h, axes=None, zoom=None, contourlabel=False, **kwargs):
             y = ndimage.zoom(y, zoom)
         z = ndimage.zoom(z, zoom)
     return_values = axes.contour(x, y, z, **kwargs)
-    if contourlabel:
+    if label_contour:
         plt.clabel(return_values)
     return return_values


### PR DESCRIPTION
By default, the plot produced with the rplt.hist2d and rplt.imshow do not have a colorbar (legend). I see how there are some use cases where one does not want to have a colorbar with each plot (eg. http://www.rootpy.org/auto_examples/plotting/plot_matplotlib_hist2d.html). However, I found it rather inconvenient that actually precise knowledge of matplotlib was needed to add that bar when all one wanted to do is get a quick overview of the histogram. Therefore, I added the option "add_cbar" to to these two functions which defaults to False to not break backwards compatibility. If set to True, a colorbar is added to the produced plots without any knowledge of the inner workings required.
