### PR TITLE
Add rootpy classes for RooPlot, RooCurve and RooHist

### DIFF
--- a/rootpy/__init__.py
+++ b/rootpy/__init__.py
@@ -187,6 +187,9 @@ INIT_REGISTRY = {
     'RooDataSet': 'stats.dataset.DataSet',
     'RooMinimizer': 'stats.fit.Minimizer',
     'RooFitResult': 'stats.fit.FitResult',
+    'RooPlot': 'stats.plottable.Plot',
+    'RooCurve': 'stats.plottable.Curve',
+    'RooHist': 'stats.plottable.Hist',
 
     'RooStats::HistFactory::Data': 'stats.histfactory.Data',
     'RooStats::HistFactory::Sample': 'stats.histfactory.Sample',

--- a/rootpy/__init__.py
+++ b/rootpy/__init__.py
@@ -189,7 +189,7 @@ INIT_REGISTRY = {
     'RooFitResult': 'stats.fit.FitResult',
     'RooPlot': 'stats.plottable.Plot',
     'RooCurve': 'stats.plottable.Curve',
-    'RooHist': 'stats.plottable.Hist',
+    'RooHist': 'stats.plottable.DataHist',
 
     'RooStats::HistFactory::Data': 'stats.histfactory.Data',
     'RooStats::HistFactory::Sample': 'stats.histfactory.Sample',

--- a/rootpy/plotting/hist.py
+++ b/rootpy/plotting/hist.py
@@ -2535,8 +2535,8 @@ class Efficiency(Plottable, NamelessConstructorObject, QROOT.TEfficiency):
         hpass = self.passed.merge_bins([bins_to_merge])
         htot = self.total.merge_bins([bins_to_merge])
         tot_eff = Efficiency(hpass, htot)
-        return (tot_eff.GetEfficiency(1), 
-                tot_eff.GetEfficiencyErrorLow(1), 
+        return (tot_eff.GetEfficiency(1),
+                tot_eff.GetEfficiencyErrorLow(1),
                 tot_eff.GetEfficiencyErrorUp(1))
 
     @property

--- a/rootpy/plotting/tests/test_hist.py
+++ b/rootpy/plotting/tests/test_hist.py
@@ -281,7 +281,7 @@ def test_overall_efficiency():
         Eff_1bin = Efficiency(Hist(1, -3, 3), Hist(1, -3, 3))
         Eff.SetStatisticOption(stat_op)
         Eff_1bin.SetStatisticOption(stat_op)
-    
+
         for i in xrange(1000):
             x = gauss(0, 3.6)
             w = uniform(0, 1)
@@ -289,11 +289,11 @@ def test_overall_efficiency():
             Eff.Fill(passed, x)
             Eff_1bin.Fill(passed, x)
 
-        assert_almost_equal(Eff.overall_efficiency(overflow=True)[0], 
+        assert_almost_equal(Eff.overall_efficiency(overflow=True)[0],
                             Eff_1bin.overall_efficiency(overflow=True)[0])
-        assert_almost_equal(Eff.overall_efficiency(overflow=True)[1], 
+        assert_almost_equal(Eff.overall_efficiency(overflow=True)[1],
                             Eff_1bin.overall_efficiency(overflow=True)[1])
-        assert_almost_equal(Eff.overall_efficiency(overflow=True)[2], 
+        assert_almost_equal(Eff.overall_efficiency(overflow=True)[2],
                             Eff_1bin.overall_efficiency(overflow=True)[2])
 
 def test_efficiency():

--- a/rootpy/stats/plottable.py
+++ b/rootpy/stats/plottable.py
@@ -13,7 +13,7 @@ from ..plotting import Graph
 __all__ = [
     'Plot',
     'Curve',
-    'Hist',
+    'DataHist',
 ]
 
 
@@ -32,9 +32,9 @@ class Plot(NamedObject, QROOT.RooPlot):
                 yield obj
 
     @property
-    def hists(self):
+    def data_hists(self):
         for obj in self.objects:
-            if isinstance(obj, Hist):
+            if isinstance(obj, DataHist):
                 yield obj
 
     @property
@@ -46,5 +46,5 @@ class Curve(NamedObject, Graph, QROOT.RooCurve):
     _ROOT = QROOT.RooCurve
 
 
-class Hist(NamedObject, Graph, QROOT.RooHist):
+class DataHist(NamedObject, Graph, QROOT.RooHist):
     _ROOT = QROOT.RooHist

--- a/rootpy/stats/plottable.py
+++ b/rootpy/stats/plottable.py
@@ -1,0 +1,50 @@
+# Copyright 2012 the rootpy developers
+# distributed under the terms of the GNU General Public License
+from __future__ import absolute_import
+
+import ROOT
+
+
+from . import log; log = log[__name__]
+from .. import QROOT, asrootpy
+from ..base import NamedObject
+from ..plotting import Graph
+
+__all__ = [
+    'Plot',
+    'Curve',
+    'Hist',
+]
+
+
+class Plot(NamedObject, QROOT.RooPlot):
+    _ROOT = QROOT.RooPlot
+
+    @property
+    def objects(self):
+        for i in xrange(0, int(self.numItems())):
+            yield asrootpy(self.getObject(i))
+
+    @property
+    def curves(self):
+        for obj in self.objects:
+            if isinstance(obj, Curve):
+                yield obj
+
+    @property
+    def hists(self):
+        for obj in self.objects:
+            if isinstance(obj, Hist):
+                yield obj
+
+    @property
+    def plotvar(self):
+        return asrootpy(self.getPlotVar())
+
+
+class Curve(NamedObject, Graph, QROOT.RooCurve):
+    _ROOT = QROOT.RooCurve
+
+
+class Hist(NamedObject, Graph, QROOT.RooHist):
+    _ROOT = QROOT.RooHist

--- a/rootpy/stats/tests/test_plottable.py
+++ b/rootpy/stats/tests/test_plottable.py
@@ -61,7 +61,7 @@ def test_plottable():
         assert_true(obj)
     for curve in mesframe.curves:
         assert_true(curve)
-    for hist in mesframe.hists:
+    for hist in mesframe.data_hists:
         assert_true(hist)
     assert_true(mesframe.plotvar)
     with TemporaryFile():

--- a/rootpy/stats/tests/test_plottable.py
+++ b/rootpy/stats/tests/test_plottable.py
@@ -1,0 +1,68 @@
+# Copyright 2012 the rootpy developers
+# distributed under the terms of the GNU General Public License
+from nose.plugins.skip import SkipTest
+from rootpy.utils.silence import silence_sout
+
+try:
+    with silence_sout():
+        import ROOT
+        from ROOT import (RooFit, RooRealVar, RooGaussian, RooArgusBG,
+                          RooAddPdf, RooArgList, RooArgSet, RooAbsData)
+    from rootpy.stats import mute_roostats; mute_roostats()
+    from rootpy import asrootpy
+
+except ImportError:
+    raise SkipTest("ROOT is not compiled with RooFit and RooStats enabled")
+
+from rootpy.io import TemporaryFile
+from nose.tools import assert_true
+
+
+def test_plottable():
+
+    # construct pdf and toy data following example at
+    # http://root.cern.ch/drupal/content/roofit
+
+    # --- Observable ---
+    mes = RooRealVar("mes", "m_{ES} (GeV)", 5.20, 5.30)
+
+    # --- Parameters ---
+    sigmean = RooRealVar("sigmean", "B^{#pm} mass", 5.28, 5.20, 5.30)
+    sigwidth = RooRealVar("sigwidth", "B^{#pm} width", 0.0027, 0.001, 1.)
+
+    # --- Build Gaussian PDF ---
+    signal = RooGaussian("signal", "signal PDF", mes, sigmean, sigwidth)
+
+    # --- Build Argus background PDF ---
+    argpar = RooRealVar("argpar", "argus shape parameter", -20.0, -100., -1.)
+    background = RooArgusBG("background", "Argus PDF",
+                            mes, RooFit.RooConst(5.291), argpar)
+
+    # --- Construct signal+background PDF ---
+    nsig = RooRealVar("nsig", "#signal events", 200, 0., 10000)
+    nbkg = RooRealVar("nbkg", "#background events", 800, 0., 10000)
+    model = RooAddPdf("model", "g+a",
+                      RooArgList(signal, background),
+                      RooArgList(nsig, nbkg))
+
+    # --- Generate a toyMC sample from composite PDF ---
+    data = model.generate(RooArgSet(mes), 2000)
+
+    # --- Perform extended ML fit of composite PDF to toy data ---
+    fitresult = model.fitTo(data, RooFit.Save(), RooFit.PrintLevel(-1))
+
+    # --- Plot toy data and composite PDF overlaid ---
+    mesframe = asrootpy(mes.frame())
+    type(mesframe)
+    data.plotOn(mesframe)
+    model.plotOn(mesframe)
+
+    for obj in mesframe.objects:
+        assert_true(obj)
+    for curve in mesframe.curves:
+        assert_true(curve)
+    for hist in mesframe.hists:
+        assert_true(hist)
+    assert_true(mesframe.plotvar)
+    with TemporaryFile():
+        mesframe.Write()


### PR DESCRIPTION
I added the rootpy version of RooPlot, RooCurve and RooHist. I also added a few additional properties to iterate over the RooPlot.

@qbuat 
