### PR TITLE
plot_corrcoef_matrix improvements

### DIFF
--- a/rootpy/stats/fit.py
+++ b/rootpy/stats/fit.py
@@ -126,6 +126,18 @@ class FitResult(QROOT.RooFitResult):
     _ROOT = QROOT.RooFitResult
 
     @property
+    def constant_params(self):
+        return asrootpy(super(FitResult, self).constPars())
+
+    @property
+    def final_params(self):
+        return asrootpy(super(FitResult, self).floatParsFinal())
+
+    @property
+    def initial_params(self):
+        return asrootpy(super(FitResult, self).floatParsInit())
+
+    @property
     def covariance_matrix(self):
         return asrootpy(super(FitResult, self).covarianceMatrix())
 


### PR DESCRIPTION
Draw correlation matrices like this one:

![correlations](https://cloud.githubusercontent.com/assets/202816/3746502/3435232e-17c0-11e4-995b-82352150a3a7.png)

``` python
import numpy as np
import matplotlib.pyplot as plt
from rootpy.io import root_open
from rootpy.plotting.contrib import plot_corrcoef_matrix
from root_numpy import matrix

# get the RooWorkspace
rfile = root_open('workspace.root')
ws = rfile['combined']

# perform an unconditional fit and get the fit result
minim = ws.fit(print_level=-1)
result = minim.save()
names = [p.name for p in result.final_params]

# get the correlation matrix and convert it into a numpy matrix
corr = matrix(result.correlation_matrix)

# compress the matrix by removing rows and columns for parameters
# that have small correlations (this is optional but saves visual space)
abs_corr = np.abs(np.asarray(corr))
abs_corr[np.triu_indices(len(abs_corr))] = 0
ignore_rows = abs_corr.max(axis=1) <= 0.1
ignore_cols = abs_corr.max(axis=0) <= 0.1
ignore = ignore_rows & ignore_cols
ignore_idx = np.flatnonzero(ignore)
corr = np.delete(corr, ignore_idx, axis=0)
corr = np.delete(corr, ignore_idx, axis=1)
keep_idx = np.flatnonzero(-ignore)
names = np.take(names, keep_idx)

# plot the correlation matrix
fig = plt.figure(figsize=(14, 14))
ax = fig.add_subplot(111)
plot_corrcoef_matrix(
    corr, names=names,
    fontsize=7, cmap='jet',
    grid=True, axes=ax)
plt.savefig('correlations.png', bbox_inches='tight', dpi=300)
```
