### PR TITLE
Only split draw expression on single colons

### DIFF
--- a/rootpy/tree/tests/test_tree.py
+++ b/rootpy/tree/tests/test_tree.py
@@ -129,6 +129,7 @@ def test_draw():
 
         tree.draw('a_x')
         tree.draw('a_x:a_y')
+        tree.draw('a_x:TMath::Exp(a_y)')
         tree.draw('a_x:a_y:a_z')
         tree.draw('a_x:a_y:a_z:b_x')
         tree.draw('a_x:a_y:a_z:b_x:b_y', options='para')

--- a/rootpy/tree/tree.py
+++ b/rootpy/tree/tree.py
@@ -707,7 +707,7 @@ class BaseTree(NamedObject):
 
         # Reverse variable order to match order in hist constructor
         exprdict = exprmatch.groupdict()
-        fields = exprdict['branches'].split(':')
+        fields = re.split('(?<!:):(?!:)', exprdict['branches'])
         num_dimensions = len(fields)
         expression = ':'.join(fields[:3][::-1] + fields[3:])
         if exprdict['redirect'] is not None:


### PR DESCRIPTION
The expression passed to `TTree.Draw()` is split on colons to change the axis ordering from ROOT's `y:x` to the more conventional `x:y`.  However this mangles expressions containing the C++ scope operator `::`, such as `var_A:TMath::Exp(var_B)`.  This commit modifies this behaviour to ignore multiple adjacent colons, and split only on single colons.
