### PR TITLE
Allow aspect argument to imshow to be overridden

### DIFF
--- a/rootpy/plotting/root2matplotlib.py
+++ b/rootpy/plotting/root2matplotlib.py
@@ -759,6 +759,8 @@ def imshow(h, axes=None, colorbar=False, **kwargs):
     Returns the value from matplotlib's imshow function.
 
     """
+    kwargs.setdefault('aspect', 'auto')
+
     if axes is None:
         axes = plt.gca()
     z = np.array(h.z()).T
@@ -769,7 +771,6 @@ def imshow(h, axes=None, colorbar=False, **kwargs):
             h.xedges(1), h.xedges(h.nbins(0) + 1),
             h.yedges(1), h.yedges(h.nbins(1) + 1)],
         interpolation='nearest',
-        aspect='auto',
         origin='lower',
         **kwargs)
     if colorbar:


### PR DESCRIPTION
The motivation for this is that I'm plotting the energy deposition density across a square detector, and want to be able to pass `aspect='equal'` so that the aspect ratio of the plot matches that of the physical detector.
