### PR TITLE
Search in python path for libs to prevent need to source thisroot.sh

### DIFF
--- a/rootpy/logger/magic.py
+++ b/rootpy/logger/magic.py
@@ -58,21 +58,24 @@ ON_RTD = os.environ.get('READTHEDOCS', None) == 'True'
 
 
 def get_dll(name):
-    try:
-        return ctypes.cdll.LoadLibrary(name + ".so")
-    except OSError:
-        pass
+    prefixes = [''] + [path_element + '/' for path_element in sys.path]
+    for prefix in prefixes:
+        base_name = prefix + name
+        try:
+            return ctypes.cdll.LoadLibrary(base_name + ".so")
+        except OSError:
+            pass
 
-    if sys.platform == "darwin":
-        try:
-            return ctypes.cdll.LoadLibrary(name + ".dylib")
-        except OSError:
-            pass
-    elif sys.platform in ("win32", "cygwin"):
-        try:
-            return ctypes.cdll.LoadLibrary(name + ".dll")
-        except OSError:
-            pass
+        if sys.platform == "darwin":
+            try:
+                return ctypes.cdll.LoadLibrary(base_name + ".dylib")
+            except OSError:
+                pass
+        elif sys.platform in ("win32", "cygwin"):
+            try:
+                return ctypes.cdll.LoadLibrary(base_name + ".dll")
+            except OSError:
+                pass
 
     raise RuntimeError("Unable to find shared object {0}.{{so,dylib,dll}}. "
                        "Did you source thisroot.sh?".format(name))


### PR DESCRIPTION
I recently built an anaconda (https://store.continuum.io/cshop/anaconda/) distribution of root, along with packages for rootpy/root_numpy. I built root with --prefix and did a lot of work to get the RPATH right so I don't need to source thisroot.sh every time. Everything seems to work fine for my conda packages, but the area in the rootpy code that I patched relies on the LD_LIBRARY_PATH (or equivalent) to be set. My modification makes it check the python path too, which will include the root lib directory in the case that you have a --prefix build.
