### PR TITLE
Add alternative short modes to root_open()

### DIFF
--- a/rootpy/io/file.py
+++ b/rootpy/io/file.py
@@ -103,7 +103,10 @@ def root_open(filename, mode=''):
         The absolute or relative path to the ROOT file.
 
     mode : string, optional (default='')
-        The ROOT option for opening a file [2].
+        Mode indicating how the file is to be opened.  This can be either one
+        of the options supported by ROOT.TFile.Open [2], or one of `a`, `a+`,
+        `r`, `r+`, `w` or `w+`, with meanings as for the built-in `open()`
+        function [3].
 
     Returns
     -------
@@ -116,8 +119,19 @@ def root_open(filename, mode=''):
 
     .. [1] http://root.cern.ch/root/html/TFile.html#TFile:Open
     .. [2] http://root.cern.ch/root/html/TFile.html#TFile:TFile@2
+    .. [3] https://docs.python.org/2/library/functions.html#open
 
     """
+    mode_map = {'a': 'UPDATE',
+                'a+': 'UPDATE',
+                'r': 'READ',
+                'r+': 'UPDATE',
+                'w': 'RECREATE',
+                'w+': 'RECREATE'}
+
+    if mode in mode_map:
+        mode = mode_map[mode]
+
     filename = expand_path(filename)
     prev_dir = ROOT.gDirectory.func()
     root_file = ROOT.R.TFile.Open(filename, mode)

--- a/rootpy/io/file.py
+++ b/rootpy/io/file.py
@@ -9,8 +9,6 @@ import os
 import re
 import uuid
 import tempfile
-import warnings
-import itertools
 from fnmatch import fnmatch
 from collections import defaultdict
 

--- a/rootpy/io/tests/test_file.py
+++ b/rootpy/io/tests/test_file.py
@@ -42,7 +42,9 @@ def test_memfile():
 def test_file_open():
 
     fname = 'test_file_open.root'
-    with File.open(fname, 'recreate'):
+    with File.open(fname, 'w'):
+        pass
+    with root_open(fname, 'r'):
         pass
     with root_open(fname):
         pass


### PR DESCRIPTION
These are based on the modes supported by the [built-in `open()` function](https://docs.python.org/2/library/functions.html#open) and provide a more Pythonic alternative to the longer ROOT options.  Instead of
```python
with root_open('foo.root', 'RECREATE'):
    pass
```
you can use
```python
with root_open('foo.root', 'w'):
    pass
```
The mapping of short modes to ROOT options is:

Short mode | ROOT option
-----------|------------
`a` | `UPDATE`
`a+` | `UPDATE`
`r` | `READ`
`r+` | `UPDATE`
`w` | `RECREATE`
`w+` | `RECREATE`