### PR TITLE
Implement GetE{X,Y}{high,low} for 1D graphs

### DIFF
--- a/rootpy/plotting/graph.py
+++ b/rootpy/plotting/graph.py
@@ -304,6 +304,26 @@ class _Graph1DBase(_GraphBase):
             raise ValueError("Attempting to get ymax of empty graph!")
         return ROOT.TMath.MaxElement(self.GetN(), self.GetY())
 
+    def GetEXhigh(self):
+        if isinstance(self, ROOT.TGraphErrors):
+            return self.GetEX()
+        return super(_Graph1DBase, self).GetEXhigh()
+
+    def GetEXlow(self):
+        if isinstance(self, ROOT.TGraphErrors):
+            return self.GetEX()
+        return super(_Graph1DBase, self).GetEXlow()
+
+    def GetEYhigh(self):
+        if isinstance(self, ROOT.TGraphErrors):
+            return self.GetEY()
+        return super(_Graph1DBase, self).GetEYhigh()
+
+    def GetEYlow(self):
+        if isinstance(self, ROOT.TGraphErrors):
+            return self.GetEY()
+        return super(_Graph1DBase, self).GetEYlow()
+
     def Crop(self, x1, x2, copy=False):
         """
         Remove points which lie outside of [x1, x2].

--- a/rootpy/plotting/tests/test_graph.py
+++ b/rootpy/plotting/tests/test_graph.py
@@ -38,6 +38,17 @@ def test_init_from_file_2d():
         assert_equal(len(g), 100)
 
 
+def test_xerr():
+    g = Graph(10)
+    list(g.xerr())
+
+    g = Graph(10, type='errors')
+    list(g.xerr())
+
+    g = Graph(10, type='asymm')
+    list(g.xerr())
+
+
 def test_divide():
     Graph.divide(Graph(Hist(10, 0, 1).FillRandom('gaus')),
                  Hist(10, 0, 1).FillRandom('gaus'), 'pois')


### PR DESCRIPTION
I came across a problem whilst plotting graphs with symmetric errors with `root2matplotlib`.  `xerrl()` calls `GetEXlow()`, which doesn't work for graphs derived from `TGraphErrors`:
```python
>>> from rootpy.plotting import Graph, root2matplotlib as r2m
>>> r2m.errorbar(Graph(3))
<Container object of 3 artists>
>>> r2m.errorbar(Graph(3, type='asymm'))
<Container object of 3 artists>
>>> r2m.errorbar(Graph(3, type='errors'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/vagrant/.local/lib/python2.7/site-packages/rootpy-dev-py2.7.egg/rootpy/plotting/root2matplotlib.py", line 551, in errorbar
    axes=axes, emptybins=emptybins, **kwargs)
  File "/home/vagrant/.local/lib/python2.7/site-packages/rootpy-dev-py2.7.egg/rootpy/plotting/root2matplotlib.py", line 580, in _errorbar
    xerr = np.array([list(h.xerrl()), list(h.xerrh())])
  File "/home/vagrant/.local/lib/python2.7/site-packages/rootpy-dev-py2.7.egg/rootpy/plotting/graph.py", line 82, in <genexpr>
    return (self.GetEXlow()[i] for i in xrange(self.GetN()))
IndexError: attempt to index a null-buffer
```
I solved this by overriding `GetEXlow()` and calling `GetEX()` in its place when the class inherits from `TGraphErrors`.  Does that seem reasonable?