### PR TITLE
[MRG] Fix #643

### DIFF
--- a/rootpy/base.py
+++ b/rootpy/base.py
@@ -6,7 +6,7 @@ This module contains base classes defining core functionality
 from __future__ import absolute_import
 
 import ROOT
-import uuid
+from .extern.shortuuid import uuid
 
 __all__ = [
     'Object',
@@ -23,7 +23,7 @@ class Object(object):
     """
     def Clone(self, name=None, title=None, shallow=False, **kwargs):
         if name is None:
-            name = uuid.uuid4().hex
+            name = '{0}_{1}'.format(self.__class__.__name__, uuid())
         if shallow:
             # use the copy constructor
             clone = self._ROOT(self)
@@ -87,7 +87,7 @@ class NamedObject(Object):
         name = kwargs.pop('name', None)
         title = kwargs.pop('title', None)
         if name is None:
-            name = uuid.uuid4().hex
+            name = '{0}_{1}'.format(self.__class__.__name__, uuid())
         if title is None:
             title = ''
         super(NamedObject, self).__init__(name, title, *args, **kwargs)
@@ -100,7 +100,7 @@ class NameOnlyObject(Object):
     def __init__(self, *args, **kwargs):
         name = kwargs.pop('name', None)
         if name is None:
-            name = uuid.uuid4().hex
+            name = '{0}_{1}'.format(self.__class__.__name__, uuid())
         super(NameOnlyObject, self).__init__(name, *args, **kwargs)
 
 
@@ -113,7 +113,7 @@ class NamelessConstructorObject(Object):
         name = kwargs.pop('name', None)
         title = kwargs.pop('title', None)
         if name is None:
-            name = uuid.uuid4().hex
+            name = '{0}_{1}'.format(self.__class__.__name__, uuid())
         if title is None:
             title = ''
         super(NamelessConstructorObject, self).__init__(*args, **kwargs)

--- a/rootpy/extern/shortuuid/COPYING
+++ b/rootpy/extern/shortuuid/COPYING
@@ -1,0 +1,29 @@
+Copyright (c) 2011, Stochastic Technologies
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met: 
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer. 
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution. 
+
+Neither the name of Stochastic Technologies nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 

--- a/rootpy/extern/shortuuid/__init__.py
+++ b/rootpy/extern/shortuuid/__init__.py
@@ -1,0 +1,111 @@
+""" Concise UUID generation. """
+
+import binascii
+import math
+import os
+import uuid as _uu
+
+
+class ShortUUID(object):
+    def __init__(self, alphabet=None):
+        if alphabet is None:
+            alphabet = list("23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
+                            "abcdefghijkmnopqrstuvwxyz")
+
+        self.set_alphabet(alphabet)
+
+    def _num_to_string(self, number, pad_to_length=None):
+        """
+        Convert a number to a string, using the given alphabet.
+        """
+        output = ""
+        while number:
+            number, digit = divmod(number, self._alpha_len)
+            output += self._alphabet[digit]
+        if pad_to_length:
+            remainder = max(pad_to_length - len(output), 0)
+            output = output + self._alphabet[0] * remainder
+        return output
+
+    def _string_to_int(self, string):
+        """
+        Convert a string to a number, using the given alphabet..
+        """
+        number = 0
+        for char in string[::-1]:
+            number = number * self._alpha_len + self._alphabet.index(char)
+        return number
+
+    def encode(self, uuid, pad_length=22):
+        """
+        Encodes a UUID into a string (LSB first) according to the alphabet
+        If leftmost (MSB) bits 0, string might be shorter
+        """
+        return self._num_to_string(uuid.int, pad_to_length=pad_length)
+
+    def decode(self, string):
+        """
+        Decodes a string according to the current alphabet into a UUID
+        Raises ValueError when encountering illegal characters
+        or too long string
+        If string too short, fills leftmost (MSB) bits with 0.
+        """
+        return _uu.UUID(int=self._string_to_int(string))
+
+    def uuid(self, name=None, pad_length=22):
+        """
+        Generate and return a UUID.
+
+        If the name parameter is provided, set the namespace to the provided
+        name and generate a UUID.
+        """
+        # If no name is given, generate a random UUID.
+        if name is None:
+            uuid = _uu.uuid4()
+        elif "http" not in name.lower():
+            uuid = _uu.uuid5(_uu.NAMESPACE_DNS, name)
+        else:
+            uuid = _uu.uuid5(_uu.NAMESPACE_URL, name)
+        return self.encode(uuid, pad_length)
+
+    def random(self, length=22):
+        """
+        Generate and return a cryptographically-secure short random string
+        of the specified length.
+        """
+        random_num = int(binascii.b2a_hex(os.urandom(length)), 16)
+        return self._num_to_string(random_num, pad_to_length=length)[:length]
+
+    def get_alphabet(self):
+        """Return the current alphabet used for new UUIDs."""
+        return ''.join(self._alphabet)
+
+    def set_alphabet(self, alphabet):
+        """Set the alphabet to be used for new UUIDs."""
+
+        # Turn the alphabet into a set and sort it to prevent duplicates
+        # and ensure reproducibility.
+        new_alphabet = list(sorted(set(alphabet)))
+        if len(new_alphabet) > 1:
+            self._alphabet = new_alphabet
+            self._alpha_len = len(self._alphabet)
+        else:
+            raise ValueError("Alphabet with more than "
+                             "one unique symbols required.")
+
+    def encoded_length(self, num_bytes=16):
+        """
+        Returns the string length of the shortened UUID.
+        """
+        factor = math.log(256) / math.log(self._alpha_len)
+        return int(math.ceil(factor * num_bytes))
+
+
+# For backwards compatibility
+_global_instance = ShortUUID()
+encode = _global_instance.encode
+decode = _global_instance.decode
+uuid = _global_instance.uuid
+random = _global_instance.random
+get_alphabet = _global_instance.get_alphabet
+set_alphabet = _global_instance.set_alphabet

--- a/rootpy/io/file.py
+++ b/rootpy/io/file.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 
 import os
 import re
-import uuid
 import tempfile
 from fnmatch import fnmatch
 from collections import defaultdict
@@ -19,6 +18,8 @@ from ..decorators import snake_case_methods
 from ..context import preserve_current_directory
 from ..utils.path import expand as expand_path
 from ..memory.keepalive import keepalive
+from ..extern.shortuuid import uuid
+
 
 __all__ = [
     'DoesNotExist',
@@ -760,7 +761,7 @@ class MemFile(_FileBase, QROOT.TMemFile):
 
     def __init__(self, name=None, mode='recreate'):
         if name is None:
-            name = uuid.uuid4().hex
+            name = '{0}_{1}'.format(self.__class__.__name__, uuid())
         super(MemFile, self).__init__(name, mode)
 
 

--- a/rootpy/plotting/hist.py
+++ b/rootpy/plotting/hist.py
@@ -6,7 +6,6 @@ from array import array
 from math import sqrt
 from itertools import product, izip
 import operator
-import uuid
 import numbers
 
 import ROOT
@@ -16,6 +15,7 @@ from ..base import NamedObject, NamelessConstructorObject
 from ..decorators import snake_case_methods, cached_property
 from ..context import invisible_canvas
 from ..utils.extras import izip_exact
+from ..extern.shortuuid import uuid
 from .base import Plottable, dim
 from .graph import Graph, _Graph1DBase
 
@@ -1412,7 +1412,7 @@ class _HistBase(Plottable, NamedObject):
                 raise ValueError(
                     "bins must be a tuple with the same "
                     "number of elements as histogram axes")
-            newname = uuid.uuid4().hex
+            newname = '{0}_{1}'.format(self.__class__.__name__, uuid())
             if ndim == 1:
                 hist = self.Rebin(bins[0], newname)
             elif ndim == 2:
@@ -1549,7 +1549,7 @@ class _HistBase(Plottable, NamedObject):
         if recompute_integral:
             self.ComputeIntegral()
         if isinstance(self, _Hist2D):
-            newname = uuid.uuid4().hex
+            newname = '{0}_{1}'.format(self.__class__.__name__, uuid())
             if axis == 0:
                 proj = self.ProjectionX(newname, 1, self.nbins(1))
             elif axis == 1:
@@ -1559,7 +1559,7 @@ class _HistBase(Plottable, NamedObject):
             return asrootpy(proj).quantiles(
                 quantiles, strict=strict, recompute_integral=False)
         elif isinstance(self, _Hist3D):
-            newname = uuid.uuid4().hex
+            newname = '{0}_{1}'.format(self.__class__.__name__, uuid())
             if axis == 0:
                 proj = self.ProjectionX(
                     newname, 1, self.nbins(1), 1, self.nbins(2))

--- a/rootpy/tree/tree.py
+++ b/rootpy/tree/tree.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 import sys
 import re
 import fnmatch
-import uuid
 
 import ROOT
 
@@ -13,6 +12,7 @@ from .. import log; log = log[__name__]
 from .. import asrootpy, QROOT
 from .. import stl
 from ..extern.ordereddict import OrderedDict
+from ..extern.shortuuid import uuid
 from ..context import set_directory, thread_specific_tmprootdir, do_nothing
 from ..base import NamedObject
 from ..decorators import snake_case_methods, method_file_check, method_file_cd
@@ -766,7 +766,7 @@ class BaseTree(NamedObject):
                     raise ValueError(
                         "Cannot create a histogram for expressions with "
                         "more than 4 dimensions")
-                newname = uuid.uuid4().hex
+                newname = '{0}_{1}'.format(self.__class__.__name__, uuid())
                 expression += '>>{0}'.format(newname)
                 exprdict['name'] = newname
 


### PR DESCRIPTION
Use shortuuid to generate concise uuids for object names and prefix name with class name to generate valid C++ in canvas.SaveAs('macro.C')