### PR TITLE
always returns rootpy

### DIFF
--- a/rootpy/decorators.py
+++ b/rootpy/decorators.py
@@ -185,6 +185,38 @@ def snake_case_methods(cls, debug=False):
         setattr(cls, new_name, value)
     return cls
 
+def asrpy(fn):
+    '''Changes the output of a function to a rootpy type'''
+    def _f(*args, **kwargs):
+        retval = fn(*args, **kwargs)
+        if isinstance(retval, tuple):
+            return tuple(asrootpy(i) for i in retval)
+        elif isinstance(retval, list):
+            return list(asrootpy(i) for i in retval)
+        else:
+            return asrootpy(fn(*args, **kwargs))
+    return _f
+
+def returns_rootpy(cls, debug=False):
+    """
+    Class decorator that ensures that each method or property returns
+    the proper rootpy object, even with ROOT methods.
+    Does not work on properties (yet) 
+    """
+    members = inspect.getmembers(cls)
+
+    for name, member in members:
+        # Is this a method?
+        if not inspect.ismethod(member) and not inspect.isfunction(member):
+            continue
+        method = getattr(cls, name)
+        setattr(
+            cls, 
+            name,
+            asrpy(method)
+            )
+
+    return cls
 
 def sync(lock):
     """

--- a/rootpy/decorators.py
+++ b/rootpy/decorators.py
@@ -7,9 +7,10 @@ import re
 import inspect
 import warnings
 from functools import wraps
+from functools import update_wrapper
 
 from .context import preserve_current_directory
-from . import ROOT, ROOT_VERSION
+from . import ROOT, ROOT_VERSION, asrootpy
 
 __all__ = [
     'requires_ROOT',
@@ -20,10 +21,17 @@ __all__ = [
     'snake_case_methods',
     'sync',
     'cached_property',
+    'returns_rootpy',
 ]
 
 
 CONVERT_SNAKE_CASE = os.getenv('NO_ROOTPY_SNAKE_CASE', False) is False
+
+def decorator(d):
+    "Make function d a decorator that wraps function fn"
+    return lambda fn: update_wrapper(d(fn),fn)
+
+decorator = decorator(decorator)
 
 
 def requires_ROOT(version, exception=False):
@@ -185,6 +193,7 @@ def snake_case_methods(cls, debug=False):
         setattr(cls, new_name, value)
     return cls
 
+@decorator
 def asrpy(fn):
     '''Changes the output of a function to a rootpy type'''
     def _f(*args, **kwargs):

--- a/rootpy/io/file.py
+++ b/rootpy/io/file.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 from .. import ROOT
 from .. import asrootpy, QROOT
 from ..base import Object, NamedObject
-from ..decorators import snake_case_methods
+from ..decorators import snake_case_methods, returns_rootpy
 from ..context import preserve_current_directory
 from ..utils.path import expand as expand_path
 from ..memory.keepalive import keepalive
@@ -149,6 +149,7 @@ def root_open(filename, mode=''):
     return root_file
 
 
+@returns_rootpy
 @snake_case_methods
 class Key(NamedObject, QROOT.TKey):
     """

--- a/rootpy/plotting/hist.py
+++ b/rootpy/plotting/hist.py
@@ -17,7 +17,7 @@ import ROOT
 from .. import asrootpy, QROOT, log; log = log[__name__]
 from ..extern.six.moves import range
 from ..base import NamedObject, NamelessConstructorObject
-from ..decorators import snake_case_methods, cached_property
+from ..decorators import snake_case_methods, cached_property, returns_rootpy
 from ..context import invisible_canvas
 from ..utils.extras import izip_exact
 from ..extern.shortuuid import uuid
@@ -2248,14 +2248,17 @@ _HIST_CLASSES_3D = {}
 
 for bintype in _HistBase.TYPES.keys():
     cls = _Hist_class(type=bintype)
+    returns_rootpy(cls)
     snake_case_methods(cls)
     _HIST_CLASSES_1D[bintype] = cls
 
     cls = _Hist2D_class(type=bintype)
+    returns_rootpy(cls)
     snake_case_methods(cls)
     _HIST_CLASSES_2D[bintype] = cls
 
     cls = _Hist3D_class(type=bintype)
+    returns_rootpy(cls)
     snake_case_methods(cls)
     _HIST_CLASSES_3D[bintype] = cls
 


### PR DESCRIPTION
Hi,

I noticed that sometimes a rootpy object does not return a rootpy object, but rather a ROOT one: e.g. Hist2D.ProjectionX and Key.ReadObj (the snake case methods are the same).

I therefore built a class decorator to fix this small issue and put it in decorators.py.
This is just the first version and I guess the same thing could be done in a better way, but I am sending the PR anyway to trigger the discussion and start implementing the improvements.

At the moment the returns_rootpy decorator is applied to the Key and Hist classes, but once the implementation is finalized can be extended to all the classes, to be safe.

So far I quickly tested the code as follows:

```
>>> import rootpy.io as io
>>> tfile = io.root_open('rootpy/testdata/test_file.root')
>>> keys = tfile.dimensions.keys()
>>> keys
[Key('hist2d'), Key('hist3d')]
>>>
>>> h2 = keys[0].ReadObj()
WARNING:ROOT.TUnixSystem.SetDisplay] DISPLAY not set, setting it to pb-d-128-141-149-159.cern.ch:0.0
>>> h2
Hist2D('hist2d')
>>> h2.ProjectionX()
Hist('hist2d_px')
>>> h2.projection_x()
Hist('hist2d_px')
```

And it seems to work.

Let me know your comments and suggestions.

Cheers