### PR TITLE
Respect inheritance in root2hdf5 executable

### DIFF
--- a/rootpy/io/file.py
+++ b/rootpy/io/file.py
@@ -538,7 +538,8 @@ class _DirectoryBase(Object):
             no limit applied by default.
 
         class_ref : class, optional (default=None)
-            If not None then only include objects that are instances ``class_ref``.
+            If not None then only include objects that are instances of
+            ``class_ref``.
 
         class_pattern : string, optional (default=None)
             If not None then only include objects in ``filenames`` with class

--- a/rootpy/io/file.py
+++ b/rootpy/io/file.py
@@ -507,6 +507,7 @@ class _DirectoryBase(Object):
              path=None,
              depth=0,
              maxdepth=-1,
+             class_ref=None,
              class_pattern=None,
              return_classname=False,
              treat_dirs_as_objs=False):
@@ -535,6 +536,9 @@ class _DirectoryBase(Object):
         max_depth : int, optional (default=-1)
             The maximum depth in the directory hierarchy to traverse. There is
             no limit applied by default.
+
+        class_ref : class, optional (default=None)
+            If not None then only include objects that are instances ``class_ref``.
 
         class_pattern : string, optional (default=None)
             If not None then only include objects in ``filenames`` with class
@@ -575,6 +579,9 @@ class _DirectoryBase(Object):
             if is_directory:
                 dirnames.append(name)
             if not is_directory or treat_dirs_as_objs:
+                if class_ref is not None:
+                    if not isinstance(tdirectory.Get(name), class_ref):
+                        continue
                 if class_pattern is not None:
                     if not fnmatch(classname, class_pattern):
                         continue
@@ -592,6 +599,7 @@ class _DirectoryBase(Object):
         for dirname in dirnames:
             rdir = tdirectory.GetDirectory(dirname)
             for x in rdir.walk(
+                    class_ref=class_ref,
                     class_pattern=class_pattern,
                     depth=depth + 1,
                     maxdepth=maxdepth,

--- a/rootpy/root2hdf5.py
+++ b/rootpy/root2hdf5.py
@@ -27,6 +27,8 @@ from .extern.progressbar import ProgressBar, Bar, ETA, Percentage
 from .extern.six import string_types
 from .logger.utils import check_tty
 
+from . import QROOT
+
 __all__ = [
     'tree2hdf5',
     'root2hdf5',
@@ -244,7 +246,7 @@ def root2hdf5(rfile, hfile, rpath='',
         own_h5file = True
 
     for dirpath, dirnames, treenames in rfile.walk(
-            rpath, class_pattern='TTree'):
+            rpath, class_ref=QROOT.TTree):
 
         # skip directories w/o trees
         if not treenames:


### PR DESCRIPTION
This PR fixes #672.
It adds an additional keyword ``class_ref`` to file walking for filtering purposes.
As a result, ``class_pattern`` is no longer used in root2hdf5.py.