### PR TITLE
WIP Return the drawn line in root2matplotlib

### DIFF
--- a/rootpy/plotting/root2matplotlib.py
+++ b/rootpy/plotting/root2matplotlib.py
@@ -286,7 +286,7 @@ def _hist(h, axes=None, bottom=None, logy=None, zorder=None, **kwargs):
                      alpha=kwargs['alpha'],
                      zorder=zorder)
     # draw the edge
-    step(h, axes=axes, logy=logy, label=None,
+    s = step(h, axes=axes, logy=logy, label=None,
          zorder=zorder + 1, alpha=kwargs['alpha'],
          color=kwargs.get('color'))
     # draw the legend proxy
@@ -302,7 +302,7 @@ def _hist(h, axes=None, bottom=None, logy=None, zorder=None, **kwargs):
                            alpha=kwargs['alpha'],
                            label=kwargs_proxy['label'])
         axes.add_line(proxy)
-    return proxy
+    return proxy, s[0]
 
 
 def bar(hists,


### PR DESCRIPTION
This pull request allows custom linestyles/dashes to be used, rather than a few default options.

This is done by returning both the drawn histogram and the legend from _hist in root2matplotlib.py.  Then set_dashes can be called by both.  Currently, only the lines appearing in a legend of a histogram can be altered with set_dashes.

This should only have an effect on usage when the return value from hist is used.