### PR TITLE
Integrate Travis with ROOT conda builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,34 @@
+#sudo: false
 # travis-ci.org build & test configuration
 language: python
-#virtualenv:
-#    system_site_packages: true
-python:
-    - "2.7"
-    #- "3.4"
-env:
-    - ROOT=5.34.34
-    - ROOT=master
-install: source ci/install.sh
+
+matrix:
+    include:
+        - python: 2.7
+          env: PYTHON=2.7 ROOT=5.34.32
+        - python: 2.7
+          env: PYTHON=2.7 ROOT=6.04
+        - python: 3.4
+          env: PYTHON=3.4 ROOT=5.34.32
+        - python: 3.4
+          env: PYTHON=3.4 ROOT=6.04
+    allow_failures:
+        - python: 3.4
+#install: source ci/install.sh
+install:
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then curl --silent http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -o miniconda.sh; fi
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then wget -nv http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
+  
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a # Useful for debugging any issues with conda
+  - conda config --add channels http://conda.anaconda.org/NLeSC  
+  - conda config --set show_channel_urls yes
+  - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
+  - source activate testenv
+
 script: bash ci/test.sh
 cache: apt

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -29,5 +29,5 @@ sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm
 ls -la /dev/shm
 
 # Now run the actual tests (from the installed version, not the local build dir)
-time make install-user
+time make install
 time make test-installed


### PR DESCRIPTION
* root-numpy dependency is picked up from conda, rather than github. Keeping the conda root-numpy package up to date is not a real time consumer, but can always be a bit behind the latest one, of course.
* didn't add uncertainties, but I see tests are not failing. If necessary, can be added.
* install.sh is not needed anymore.
* There is only one use of sudo, for the shared memory issue. If that's historic, the Travis tests can run in container (faster).
* Added python 3 in the matrix, just because we can.