### PR TITLE
fixing location of ez_setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ except ImportError as ex:
     sys.exit(
         "{0}\n\n"
         "rootpy requires that at least setuptools 0.7 is installed:\n\n"
-        "wget https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py\n"
+        "wget https://bootstrap.pypa.io/ez_setup.py\n"
         "python ez_setup.py --user\n\n"
         "You might need to add the --insecure option to the last command above "
         "if using an old version of wget.\n\n"


### PR DESCRIPTION
The location of ez_setup.py in setup.py is no longer correct : 

```wget https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py
--2016-06-29 23:56:52--  https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py
Resolving bitbucket.org... 104.192.143.1, 104.192.143.2, 104.192.143.3
Connecting to bitbucket.org|104.192.143.1|:443... connected.
HTTP request sent, awaiting response... 404 NOT FOUND
2016-06-29 23:56:53 ERROR 404: NOT FOUND.```

This pull request fixes this to the location based on  [https://pypi.python.org/pypi/setuptools](url)