### PR TITLE
Give HistStack a new argument: stacked

### DIFF
--- a/rootpy/info.py
+++ b/rootpy/info.py
@@ -9,7 +9,7 @@
                     |_|    |___/
       {0}
 """
-__version__ = '0.8.2.dev0'
+__version__ = '0.8.3.dev0'
 __url__ = 'http://rootpy.github.com/rootpy'
 __repo_url__ = 'https://github.com/rootpy/rootpy/'
 __download_url__ = ('http://pypi.python.org/packages/source/r/'

--- a/rootpy/plotting/tests/test_hist.py
+++ b/rootpy/plotting/tests/test_hist.py
@@ -136,6 +136,25 @@ def test_stack():
     stack2 = stack.Clone()
     assert_equal(stack2[2].linecolor, 'green')
 
+    # test stacked=True
+    a = Hist(2, 0, 1)
+    b = Hist(2, 0, 1)
+    a.Fill(0.2)
+    b.Fill(0.2)
+    b.Fill(0.8, 5)
+    stack = HistStack([a, b])
+    assert_equal(stack.min(), 2)
+    assert_equal(stack.max(), 5)
+
+    # test stacked=False
+    a = Hist(2, 0, 20)
+    b = Hist(2, 10, 20)  # binning may be different
+    a.Fill(0.2)
+    b.Fill(15, 5)
+    stack = HistStack([a, b], stacked=False)
+    assert_equal(stack.min(), 0)
+    assert_equal(stack.max(), 5)
+
 
 def test_indexing():
     hist = Hist(10, 0, 1)


### PR DESCRIPTION
True by default but if False then min() and max() treat contained histograms separately. Histograms may then have different binnings. This is useful if HistStack is only used to act as a container holding histograms and will be drawn with the NOSTACK option. xref #699 