### PR TITLE
fix #702: File needs to set _prev_dir in post_init

### DIFF
--- a/rootpy/io/file.py
+++ b/rootpy/io/file.py
@@ -627,13 +627,16 @@ class Directory(_DirectoryBase, QROOT.TDirectoryFile):
     def __init__(self, name, title=None, classname='', parent=None):
         if title is None:
             title = name
+        # grab previous directory before creating self
+        self._prev_dir = ROOT.gDirectory.func()
         super(Directory, self).__init__(name, title, classname, parent or 0)
         self._post_init()
 
     def _post_init(self):
         self._path = self.GetName()
-        self._parent = ROOT.gDirectory.func()
-        self._prev_dir = None
+        # need to set _prev_dir here again if using rootpy.ROOT.TDirectory
+        self._prev_dir = getattr(self, '_prev_dir', None)
+        self._parent = self._prev_dir
         self._inited = True
 
 
@@ -649,9 +652,9 @@ class _FileBase(_DirectoryBase):
 
     def _post_init(self):
         self._path = self.GetName()
-        self._parent = self
         # need to set _prev_dir here again if using rootpy.ROOT.TFile
         self._prev_dir = getattr(self, '_prev_dir', None)
+        self._parent = self
         self._inited = True
 
     def _populate_cache(self):

--- a/rootpy/io/file.py
+++ b/rootpy/io/file.py
@@ -629,6 +629,7 @@ class Directory(_DirectoryBase, QROOT.TDirectoryFile):
             title = name
         # grab previous directory before creating self
         self._prev_dir = ROOT.gDirectory.func()
+        self._parent = parent or self._prev_dir
         super(Directory, self).__init__(name, title, classname, parent or 0)
         self._post_init()
 
@@ -636,7 +637,7 @@ class Directory(_DirectoryBase, QROOT.TDirectoryFile):
         self._path = self.GetName()
         # need to set _prev_dir here again if using rootpy.ROOT.TDirectory
         self._prev_dir = getattr(self, '_prev_dir', None)
-        self._parent = self._prev_dir
+        self._parent = getattr(self, '_parent', self._prev_dir)
         self._inited = True
 
 

--- a/rootpy/io/file.py
+++ b/rootpy/io/file.py
@@ -229,7 +229,7 @@ class _DirectoryBase(Object):
         """
         cd to the gDirectory before this file was open.
         """
-        if isinstance(self._prev_dir, ROOT.TROOT):
+        if self._prev_dir is None or isinstance(self._prev_dir, ROOT.TROOT):
             return False
         if isinstance(self._prev_dir, ROOT.TFile):
             if self._prev_dir.IsOpen() and self._prev_dir.IsWritable():
@@ -642,6 +642,7 @@ class _FileBase(_DirectoryBase):
     def __init__(self, name, *args, **kwargs):
         # trigger finalSetup
         ROOT.R.kTRUE
+        # grab previous directory before creating self
         self._prev_dir = ROOT.gDirectory.func()
         super(_FileBase, self).__init__(name, *args, **kwargs)
         self._post_init()
@@ -649,6 +650,8 @@ class _FileBase(_DirectoryBase):
     def _post_init(self):
         self._path = self.GetName()
         self._parent = self
+        # need to set _prev_dir here again if using rootpy.ROOT.TFile
+        self._prev_dir = getattr(self, '_prev_dir', None)
         self._inited = True
 
     def _populate_cache(self):

--- a/rootpy/io/tests/test_file.py
+++ b/rootpy/io/tests/test_file.py
@@ -45,6 +45,8 @@ def test_file_open():
         pass
     with root_open(fname):
         pass
+    with ROOT.TFile(fname, 'recreate') as f:
+        assert_true(isinstance(f, File))
     os.unlink(fname)
 
 


### PR DESCRIPTION
xref: #702 

This now works:

```python
from rootpy import ROOT

with ROOT.TFile('ads.root', 'recreate') as f:
    pass
```