### PR TITLE
fixed "local variable new_dir referenced before assignment" in copytree

### DIFF
--- a/rootpy/io/file.py
+++ b/rootpy/io/file.py
@@ -482,6 +482,8 @@ class _DirectoryBase(Object):
                 if cp_name not in dest_dir:
                     # Destination directory doesn't exist, so make a new one
                     new_dir = dest_dir.mkdir(cp_name)
+                else:
+                    new_dir = dest_dir.get(cp_name)
                 # Copy everything in the src directory to the destination
                 for (path, dirnames, objects) in src.walk(maxdepth=0):
                     # Copy all the objects


### PR DESCRIPTION
While trying to find a faster way to merge files with unique content, I discovered a bug in `copytree`.
The example code is

``` python
from rootpy.io import root_open, TemporaryFile
from rootpy.testdata import get_filepath
from collections import Counter
files = [get_filepath(), get_filepath()]

with TemporaryFile() as output_file:
    dest_dir = output_file.get('')
    for file_name in files:
        with root_open(file_name) as f:
            for path, _, _ in f.walk():
                # only copy the first set of directories
                if path == '' or Counter(path)['/'] > 0:
                    continue
                f.copytree(dest_dir = output_file, src = path, overwrite=True)
```

The `copytree` fails because `new_dir` is not assigned.

`#hacktoberfest` ?
