### PR TITLE
FIX #772: put ROOT in batch mode if libGui can't be loaded

### DIFF
--- a/rootpy/utils/quickroot.py
+++ b/rootpy/utils/quickroot.py
@@ -65,6 +65,12 @@ class QuickROOT(object):
                     if Load(libname) == 0:
                         log.debug("Loaded {0} (required by {1})".format(
                             libname, symbol))
+                    elif lib == 'Gui':
+                        # Possibly no X11 forwarding
+                        log.debug("Unable to load {0} (required by {1}). "
+                                  "Putting ROOT in batch mode.".format(
+                            libname, symbol))
+                        ROOT.gROOT.SetBatch(True)
                     else: # pragma: no cover
                         raise RuntimeError(
                             "Unable to load {0} (required by {1})".format(


### PR DESCRIPTION
xref #772 

Now this is the result:

```
DEBUG=1 python
>>> from rootpy.plotting import Hist
DEBUG:rootpy.logger] Adding rootpy's default logging handler to the root logger
DEBUG:rootpy.logger.magic] called SetErrorHandler()
DEBUG:rootpy.utils.quickroot] Loaded libHist (required by TH1)
DEBUG:rootpy] Using ROOT 6.10/04
DEBUG:rootpy.stl] Using /home/edawe/.cache/rootpy/x86_64-61004/include_paths.list to get additional include paths
WARNING:ROOT.TUnixSystem.SetDisplay] DISPLAY not set, setting it to ...unimelb.net.au:0.0
DEBUG:rootpy.utils.quickroot] Unable to load libGui (required by TPad). Putting ROOT in batch mode.
```