### PR TITLE
Fix Hist setitem when assigning to list of value, error tuples

### DIFF
--- a/rootpy/plotting/hist.py
+++ b/rootpy/plotting/hist.py
@@ -679,7 +679,7 @@ class _HistBase(Plottable, NamedObject):
                     self.SetBinContent(i, v.value)
                     self.SetBinError(i, v.error)
             elif hasattr(value, '__iter__') and not isinstance(value, tuple):
-                if value and isinstance(value[0], tuple):
+                if isinstance(value[0], tuple):
                     for i, v in izip_exact(indices, value):
                         _value, _error = v
                         self.SetBinContent(i, _value)

--- a/rootpy/plotting/hist.py
+++ b/rootpy/plotting/hist.py
@@ -681,7 +681,7 @@ class _HistBase(Plottable, NamedObject):
             elif hasattr(value, '__iter__') and not isinstance(value, tuple):
                 if value and isinstance(value[0], tuple):
                     for i, v in izip_exact(indices, value):
-                        _value, _error = value
+                        _value, _error = v
                         self.SetBinContent(i, _value)
                         self.SetBinError(i, _error)
                 else:

--- a/rootpy/plotting/tests/test_hist.py
+++ b/rootpy/plotting/tests/test_hist.py
@@ -173,6 +173,13 @@ def test_slice_assign():
     assert all([a.value == b.value for a, b in zip(hist, clone[::-1])])
 
 
+def test_slice_assign_error():
+    hist = Hist(10, 0, 1)
+    hist[:] = [(i, i/2.) for i in range(len(hist))]
+    assert all([a.value == b for a, b in zip(hist, range(len(hist)))])
+    assert all([a.error == b/2. for a, b in zip(hist, range(len(hist)))])
+
+
 @raises(LengthMismatch)
 def test_slice_assign_bad():
     hist = Hist(10, 0, 1)


### PR DESCRIPTION
There was a bug in the way the (contents, error) tuples were unpacked, in that we unpacked `value` which contains all bins, rather than `v` which contains just the contents and error for the current bin.  This particular use case wasn't being tested for so I've added a dedicated unit test as well.

In addition, I've removed a check that `value` is valid, since by this point it shouldn't be needed.