### PR TITLE
Fix compiler issue in travis build jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ install:
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
-  - apt-get update
-  - apt-get install build-essential
-  - apt-get install libstdc++6
-  - cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
+  - sudo apt-get update
+  - sudo apt-get install build-essential
+  - sudo apt-get install libstdc++6
+  - cp -v /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
 
 script: bash ci/test.sh
 cache: apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ install:
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
   - sudo apt-get install libstdc++6
-  - cp -v /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
-    #- rm $CONDA_PREFIX/lib/libstdc++.so.6
-    #- ln -s $CONDA_PREFIX/lib/libstdc++.so.6.0.24 $CONDA_PREFIX/lib/libstdc++.so.6
+    #- cp -v /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
+  - rm $CONDA_PREFIX/lib/libstdc++.so.6
+  - ln -s $CONDA_PREFIX/lib/libstdc++.so.6.0.24 $CONDA_PREFIX/lib/libstdc++.so.6
     #- export DISPLAY=localhost:0.0
 
     #- sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ install:
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
-  - cd $CONDA_PREFIX/lib
   - rm $CONDA_PREFIX/lib/libstdc++.so.6
   - ln -s $CONDA_PREFIX/lib/libstdc++.so.6.0.24 $CONDA_PREFIX/lib/libstdc++.so.6
   - export DISPLAY=localhost:0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ install:
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
   - cd $CONDA_PREFIX/lib
-  - rm libstdc++.so.6
-  - ln -s libstdc++.so.6.0.24 libstdc++.so.6
-  - cd -
+  - rm $CONDA_PREFIX/lib/libstdc++.so.6
+  - ln -s $CONDA_PREFIX/lib/libstdc++.so.6.0.24 $CONDA_PREFIX/lib/libstdc++.so.6
+  - export DISPLAY=localhost:0.0
 
     #- sudo apt-get update
     #- sudo apt-get install build-essential

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ install:
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --set show_channel_urls yes
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
-  - conda install libgcc=5.2.0
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
+  - conda remove gcc libgcc
     #- rm $CONDA_PREFIX/lib/libstdc++.so.6
     #- ln -s $CONDA_PREFIX/lib/libstdc++.so.6.0.24 $CONDA_PREFIX/lib/libstdc++.so.6
     #- export DISPLAY=localhost:0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
   - sudo apt-get install build-essential
   - sudo apt-get install gcc-4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,12 @@ install:
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
-  - conda remove gcc libgcc
+  - sudo apt-get update
+  - sudo apt-get install build-essential
+  - sudo apt-get install libstdc++6
+  - cp -v /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
+  - strings $CONDA_PREFIX/lib/libstdc++.so.6 | grep CXXABI_1.3.9
+  - strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep CXXABI_1.3.9
     #- rm $CONDA_PREFIX/lib/libstdc++.so.6
     #- ln -s $CONDA_PREFIX/lib/libstdc++.so.6.0.24 $CONDA_PREFIX/lib/libstdc++.so.6
     #- export DISPLAY=localhost:0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,27 +5,26 @@ language: python
 matrix:
     include:
         - python: 2.7
-          env: PYTHON=2.7 ROOT=5.34.32
+          env: PYTHON=2.7 CONDA_PY=2 ROOT=5.34.32
         - python: 2.7
-          env: PYTHON=2.7 ROOT=6.04
+          env: PYTHON=2.7 CONDA_PY=2 ROOT=6.04
         - python: 3.4
-          env: PYTHON=3.4 ROOT=5.34.32
+          env: PYTHON=3.4 CONDA_PY=3 ROOT=5.34.32
         - python: 3.4
-          env: PYTHON=3.4 ROOT=6.04
+          env: PYTHON=3.4 CONDA_PY=3 ROOT=6.04
     allow_failures:
         - python: 3.4
-          env: PYTHON=3.4 ROOT=5.34.32
+          env: PYTHON=3.4 CONDA_PY=3 ROOT=5.34.32
 #install: source ci/install.sh
 install:
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then curl --silent http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -o miniconda.sh; fi
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then wget -nv http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then curl --silent http://repo.continuum.io/miniconda/Miniconda${CONDA_PY}-latest-MacOSX-x86_64.sh -o miniconda.sh; fi
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then wget -nv http://repo.continuum.io/miniconda/Miniconda${CONDA_PY}-latest-Linux-x86_64.sh -O miniconda.sh; fi
 
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda install libgcc
   - conda info -a # Useful for debugging any issues with conda
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --set show_channel_urls yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
-  - locate libstdc++.so.6
+  - find / -name libstdc++.so.6 2>/dev/null
 
 script: bash ci/test.sh
 cache: apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
   - cd $CONDA_PREFIX/lib
   - rm libstdc++.so.6
   - ln -s libstdc++.so.6.0.24 libstdc++.so.6
+  - cd -
 
     #- sudo apt-get update
     #- sudo apt-get install build-essential

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
   - sudo apt-get install build-essential
-  - sudo apt-get install gcc-4.9
+  - sudo apt-get install gcc-4.9 g++-4.9
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
   - sudo apt-get install libstdc++6
   - cp -v /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
     #- rm $CONDA_PREFIX/lib/libstdc++.so.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,20 @@ language: python
 matrix:
     include:
         - python: 2.7
-          env: PYTHON=2.7 CONDA_PY=3 ROOT=5.34.32
+          env: PYTHON=2.7 ROOT=5.34.32
         - python: 2.7
-          env: PYTHON=2.7 CONDA_PY=3 ROOT=6.04
+          env: PYTHON=2.7 ROOT=6.04
         - python: 3.4
-          env: PYTHON=3.4 CONDA_PY=3 ROOT=5.34.32
+          env: PYTHON=3.4 ROOT=5.34.32
         - python: 3.4
-          env: PYTHON=3.4 CONDA_PY=3 ROOT=6.04
+          env: PYTHON=3.4 ROOT=6.04
     allow_failures:
         - python: 3.4
           env: PYTHON=3.4 CONDA_PY=3 ROOT=5.34.32
 #install: source ci/install.sh
 install:
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then curl --silent http://repo.continuum.io/miniconda/Miniconda${CONDA_PY}-latest-MacOSX-x86_64.sh -o miniconda.sh; fi
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then wget -nv http://repo.continuum.io/miniconda/Miniconda${CONDA_PY}-latest-Linux-x86_64.sh -O miniconda.sh; fi
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then curl --silent http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -o miniconda.sh; fi
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then wget -nv http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
 
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
@@ -31,6 +31,8 @@ install:
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
+
+    #Manually upgrade gcc and link libstdc++.so.6 to libstdc++.so.6.0.24
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
   - sudo apt-get install build-essential
@@ -38,15 +40,8 @@ install:
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
   - sudo apt-get install libstdc++6
-    #- cp -v /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
   - rm $CONDA_PREFIX/lib/libstdc++.so.6
   - ln -s $CONDA_PREFIX/lib/libstdc++.so.6.0.24 $CONDA_PREFIX/lib/libstdc++.so.6
-    #- export DISPLAY=localhost:0.0
-
-    #- sudo apt-get update
-    #- sudo apt-get install build-essential
-    #- sudo apt-get install libstdc++6
-    #- cp -v /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
 
 script: bash ci/test.sh
 cache: apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ install:
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
   - sudo apt-get update
+  - sudo apt-get upgrade
+  - sudo apt-get dist-upgrade
   - sudo apt-get install build-essential
   - sudo apt-get install libstdc++6
   - cp -v /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
-  - strings $CONDA_PREFIX/lib/libstdc++.so.6 | grep CXXABI_1.3.9
-  - strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep CXXABI_1.3.9
     #- rm $CONDA_PREFIX/lib/libstdc++.so.6
     #- ln -s $CONDA_PREFIX/lib/libstdc++.so.6.0.24 $CONDA_PREFIX/lib/libstdc++.so.6
     #- export DISPLAY=localhost:0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
-  - find / -name libstdc++.so.6 2>/dev/null
+  - cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
 
 script: bash ci/test.sh
 cache: apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,12 @@ install:
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --set show_channel_urls yes
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
+  - conda install libgcc=5.2.0
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
-  - rm $CONDA_PREFIX/lib/libstdc++.so.6
-  - ln -s $CONDA_PREFIX/lib/libstdc++.so.6.0.24 $CONDA_PREFIX/lib/libstdc++.so.6
-  - export DISPLAY=localhost:0.0
+    #- rm $CONDA_PREFIX/lib/libstdc++.so.6
+    #- ln -s $CONDA_PREFIX/lib/libstdc++.so.6.0.24 $CONDA_PREFIX/lib/libstdc++.so.6
+    #- export DISPLAY=localhost:0.0
 
     #- sudo apt-get update
     #- sudo apt-get install build-essential

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ language: python
 matrix:
     include:
         - python: 2.7
-          env: PYTHON=2.7 CONDA_PY=2 ROOT=5.34.32
+          env: PYTHON=2.7 CONDA_PY=3 ROOT=5.34.32
         - python: 2.7
-          env: PYTHON=2.7 CONDA_PY=2 ROOT=6.04
+          env: PYTHON=2.7 CONDA_PY=3 ROOT=6.04
         - python: 3.4
           env: PYTHON=3.4 CONDA_PY=3 ROOT=5.34.32
         - python: 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
-  - cp /usr/lib/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
+  - locate libstdc++.so.6
 
 script: bash ci/test.sh
 cache: apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,15 @@ matrix:
 install:
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then curl --silent http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -o miniconda.sh; fi
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then wget -nv http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
-  
+
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
+  - conda install libgcc
   - conda info -a # Useful for debugging any issues with conda
-  - conda config --add channels http://conda.anaconda.org/NLeSC  
+  - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --set show_channel_urls yes
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
           env: PYTHON=3.4 ROOT=6.04
     allow_failures:
         - python: 3.4
-          env: PYTHON=3.4 CONDA_PY=3 ROOT=5.34.32
+          env: PYTHON=3.4 ROOT=5.34.32
 #install: source ci/install.sh
 install:
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then curl --silent http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -o miniconda.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,14 @@ install:
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
-  - sudo apt-get update
-  - sudo apt-get install build-essential
-  - sudo apt-get install libstdc++6
-  - cp -v /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
+  - cd $CONDA_PREFIX/lib
+  - rm libstdc++.so.6
+  - ln -s libstdc++.so.6.0.24 libstdc++.so.6
+
+    #- sudo apt-get update
+    #- sudo apt-get install build-essential
+    #- sudo apt-get install libstdc++6
+    #- cp -v /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
 
 script: bash ci/test.sh
 cache: apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ install:
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
+  - apt-get update
+  - apt-get install build-essential
+  - apt-get install libstdc++6
   - cp /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
 
 script: bash ci/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,10 @@ install:
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
   - sudo apt-get update
-  - sudo apt-get upgrade
-  - sudo apt-get dist-upgrade
   - sudo apt-get install build-essential
+  - sudo apt-get install gcc-4.9
   - sudo apt-get install libstdc++6
   - cp -v /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
     #- rm $CONDA_PREFIX/lib/libstdc++.so.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,9 @@ install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
   - sudo apt-get install build-essential
-  - sudo apt-get install gcc-4.9 g++-4.9
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
+  - sudo apt-get -qq install g++-4.8
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
   - sudo apt-get install libstdc++6
   - cp -v /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
     #- rm $CONDA_PREFIX/lib/libstdc++.so.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
   - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
+  - cp /usr/lib/libstdc++.so.6 /home/travis/miniconda/envs/testenv/bin/../lib/
 
 script: bash ci/test.sh
 cache: apt


### PR DESCRIPTION
Hi,

I have noticed that all recent pull requests fail to pass tests on Travis-CI. This happens because of Miniconda's default version of gcc and libgc.  I think this issue is known, but so far there is no offical fix to it. 
So I've a workaround, which will give us possibility to further test all commits and pull requests on git and continue the development. I've updated .travic.yml file and all mandatory 3 build jobs are now getting passed. Then I've tested to merge one of the active PR #785 to my fork and here are the results from Travis-CI:  https://travis-ci.com/rakab/rootpy/builds/81817313

I had no ability to locally test travis jobs, so I had to do all the development and tests on GitHub, resulting so many commits. But I guess it can be squashed and merged if that's more appropriate and you decide to accept this PR.

Cheers