### PR TITLE
Complex ternary cuts

### DIFF
--- a/rootpy/tree/cut.py
+++ b/rootpy/tree/cut.py
@@ -50,9 +50,10 @@ def _expand_ternary(match):
 
 
 _TERNARY = re.compile(
-    '(?P<left>[a-zA-Z0-9_\.]+[<>=]+)'
-    '(?P<name>\w+)'
-    '(?P<right>[<>=]+[a-zA-Z0-9_\.]+)')
+    '(?P<left>[a-zA-Z0-9_\.\+\-\*\/]+[<>=]+)'
+    '(?P<name>[\w\.\+\-\*\/]+)'
+    '(?P<right>[<>=]+[a-zA-Z0-9_\.\+\-\*\/]+)')
+
 
 
 class Cut(QROOT.TCut):

--- a/rootpy/tree/cut.py
+++ b/rootpy/tree/cut.py
@@ -51,8 +51,9 @@ def _expand_ternary(match):
 
 _TERNARY = re.compile(
     '(?P<left>[a-zA-Z0-9_\.\+\-\*\/]+[<>=]+)'
-    '(?P<name>[\w\.\+\-\*\/]+)'
+    '(?P<name>[\w\.\+\-\*\/\(\)]+)'
     '(?P<right>[<>=]+[a-zA-Z0-9_\.\+\-\*\/]+)')
+
 
 
 

--- a/rootpy/tree/tests/test_cut.py
+++ b/rootpy/tree/tests/test_cut.py
@@ -8,6 +8,7 @@ def test_safe():
     assert_equal(Cut("var**2").safe(), "var_pow_2")
     assert_equal(Cut("var*2").safe(), "var_mul_2")
     assert_equal(Cut("2*var**2").safe(), "2_mul_var_pow_2")
+    assert_equal(Cut("-4+1<fabs(var)*1e-3<4*10").safe(), "L-4+1_lt_fabsLvarR_mul_1e-3R_and_LfabsLvarR_mul_1e-3_lt_4_mul_10R")
 
 if __name__ == "__main__":
     import nose


### PR DESCRIPTION
Added ability to use more complex ternary cuts in ```tree.draw``` , for example:
```python
Cut('40*1e3 < jet_pt < 50*1e3')
#or
Cut('40 < jet_pt*1e-3 < 50')
```