### PR TITLE
Updated travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,9 @@ install:
   - source activate testenv
 
     #Link libstdc++.so.6 to libstdc++.so.6.0.2 to avoid gcc abi issues
-  - rm $CONDA_PREFIX/lib/libstdc++.so.6
-  - ln -s $CONDA_PREFIX/lib/libstdc++.so.6.0.24 $CONDA_PREFIX/lib/libstdc++.so.6
+  #- rm $CONDA_PREFIX/lib/libstdc++.so.6
+  - ls $CONDA_PREFIX/lib/
+  #- ln -s $CONDA_PREFIX/lib/libstdc++.so.6.0.24 $CONDA_PREFIX/lib/libstdc++.so.6
 
 script: bash ci/test.sh
 cache: apt

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,13 @@ install:
   - conda info -a # Useful for debugging any issues with conda
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --set show_channel_urls yes
-  - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables
+  - conda create -q -n testenv python=${PYTHON} root=${ROOT} root-numpy numpy matplotlib nose sphinx pytables openssl=1.0.2p
   - export CONDA_ENV_PATH=$HOME/miniconda/envs/testenv
   - source activate testenv
 
     #Link libstdc++.so.6 to libstdc++.so.6.0.2 to avoid gcc abi issues
-  #- rm $CONDA_PREFIX/lib/libstdc++.so.6
-  - ls $CONDA_PREFIX/lib/
-  #- ln -s $CONDA_PREFIX/lib/libstdc++.so.6.0.24 $CONDA_PREFIX/lib/libstdc++.so.6
+  - rm $CONDA_PREFIX/lib/libstdc++.so.6
+  - ln -sv $CONDA_PREFIX/lib/libstdc++.so.6.0.25 $CONDA_PREFIX/lib/libstdc++.so.6
 
 script: bash ci/test.sh
 cache: apt


### PR DESCRIPTION
Travis jobs for python2 are getting broken again. This is caused by updated version of openssl, downgrading it solves the issue.

This is most likely temporary solution and travis config will require some updates again soon, but since root-conda-recipes development is rather slow, that's the only way to keep working travis builds.