### PR TITLE
Fix Graph Crop() function

### DIFF
--- a/rootpy/plotting/graph.py
+++ b/rootpy/plotting/graph.py
@@ -93,7 +93,7 @@ class _GraphBase(object):
                 if self.isdefault: return
                 getattr(
                     self.graph_,
-                    'voidSetPointE{0}low'.format(self.axis_.upper())
+                    'SetPointE{0}low'.format(self.axis_.upper())
                     )(self.index_, val)
 
 

--- a/rootpy/plotting/graph.py
+++ b/rootpy/plotting/graph.py
@@ -93,7 +93,7 @@ class _GraphBase(object):
                 if self.isdefault: return
                 getattr(
                     self.graph_,
-                    'SetPointE{0}low'.format(self.axis_.upper())
+                    'voidSetPointE{0}low'.format(self.axis_.upper())
                     )(self.index_, val)
 
 
@@ -410,22 +410,22 @@ class _Graph1DBase(_GraphBase):
     def GetXmin(self):
         if len(self) == 0:
             raise ValueError("Attemping to get xmin of empty graph")
-        return ROOT.TMath.MinElement(self.GetN(), self.GetX())
+        return min(list(self.x()))
 
     def GetXmax(self):
         if len(self) == 0:
             raise ValueError("Attempting to get xmax of empty graph")
-        return ROOT.TMath.MaxElement(self.GetN(), self.GetX())
+        return max(list(self.x()))
 
     def GetYmin(self):
         if len(self) == 0:
             raise ValueError("Attempting to get ymin of empty graph")
-        return ROOT.TMath.MinElement(self.GetN(), self.GetY())
+        return min(list(self.y()))
 
     def GetYmax(self):
         if len(self) == 0:
             raise ValueError("Attempting to get ymax of empty graph!")
-        return ROOT.TMath.MaxElement(self.GetN(), self.GetY())
+        return max(list(self.y()))
 
     def GetEXhigh(self):
         if isinstance(self, ROOT.TGraphErrors):
@@ -461,6 +461,7 @@ class _Graph1DBase(_GraphBase):
         else:
             cropGraph = self
             copyGraph = self.Clone()
+        cropGraph.Set(0)
         X = copyGraph.GetX()
         EXlow = copyGraph.GetEXlow()
         EXhigh = copyGraph.GetEXhigh()
@@ -468,25 +469,24 @@ class _Graph1DBase(_GraphBase):
         EYlow = copyGraph.GetEYlow()
         EYhigh = copyGraph.GetEYhigh()
         xmin = copyGraph.GetXmin()
-        if x1 < xmin:
+        if x1 < xmin-EXlow[0]:
             cropGraph.Set(numPoints + 1)
-            numPoints += 1
         xmax = copyGraph.GetXmax()
-        if x2 > xmax:
+        if x2 > xmax+EXhigh[numPoints-1]:
             cropGraph.Set(numPoints + 1)
-            numPoints += 1
         index = 0
         for i in range(numPoints):
             if i == 0 and x1 < xmin:
                 cropGraph.SetPoint(0, x1, copyGraph.Eval(x1))
-            elif i == numPoints - 1 and x2 > xmax:
+                index += 1
+            elif i == numPoints-1 and x2 > xmax+EXhigh[i]:
                 cropGraph.SetPoint(i, x2, copyGraph.Eval(x2))
-            else:
-                cropGraph.SetPoint(i, X[index], Y[index])
+            if x1<=X[i]-EXlow[i] and X[i]+EXhigh[i]<=x2:
+                cropGraph.SetPoint(index, X[i], Y[i])
                 cropGraph.SetPointError(
-                    i,
-                    EXlow[index], EXhigh[index],
-                    EYlow[index], EYhigh[index])
+                    index,
+                    EXlow[i], EXhigh[i],
+                    EYlow[i], EYhigh[i])
                 index += 1
         return cropGraph
 


### PR DESCRIPTION
Hi,

`Crop(x1, x2)` function of the graph module doesn't work correctly.  Current version of the code copies the whole graph and does a perfect job adding interpolated values if x1<x_min of the graph or x2>x_max , but if x1, x2 fit in [x_min, x_max] range all outlier points should be removed, which isn't the case.
Here is simple code to reproduce this issue:
```python
from rootpy.plotting import Graph, Canvas

g = Graph(10)
i=0
for point in g:
    point.x.value = i
    point.y.value = i
    i = i+1

c = Canvas()
c.draw()
g.draw('aplsame')
g1 = g.Crop(3,5,copy=True)
g1.color = 'red'
g1.draw('plsame')
``` 
Current version produces a plot like this:
![old](https://user-images.githubusercontent.com/13122939/50546611-d062f880-0c43-11e9-847d-78cac2d862d6.png)
After adding the changes in this commit it looks as it's expected like this: 
![new](https://user-images.githubusercontent.com/13122939/50546620-e670b900-0c43-11e9-8328-da43c12db902.png)

Also current methods to get min or max element of the axis `GetXmin()`, `GetYmin`, `GetXmax` and `GetYmax` rise exception in python3. They are now modified as well and updated version works for both python versions.

Cheers,
Bakar  