### PR TITLE
Fixed issue #805: invalid escape sequence in BaseTree.DRAW_PATTERN

### DIFF
--- a/rootpy/tree/tree.py
+++ b/rootpy/tree/tree.py
@@ -41,10 +41,10 @@ class UserData(object):
 class BaseTree(NamedObject):
 
     DRAW_PATTERN = re.compile(
-        '^(?P<branches>.+?)'
-        '(?P<redirect>\>\>[\+]?'
-        '(?P<name>[^\(]+)'
-        '(?P<binning>.+)?)?$')
+        r'^(?P<branches>.+?)'
+        r'(?P<redirect>>>[\+]?'
+        r'(?P<name>[^(]+)'
+        r'(?P<binning>.+)?)?$')
 
     def _post_init(self):
         """


### PR DESCRIPTION
Fixes #805.

 - converted `BaseTree.DRAW_PATTERN` into raw string
 - removed invalid escape sequences