### PR TITLE
fixes #812 (python 3.8 import error)

### DIFF
--- a/rootpy/logger/formatter.py
+++ b/rootpy/logger/formatter.py
@@ -5,6 +5,7 @@ to insert ANSI color codes.
 from __future__ import absolute_import
 
 import logging
+import sys
 
 __all__ = [
     'CustomFormatter',
@@ -37,7 +38,10 @@ COLORS = {
 
 class CustomFormatter(logging.Formatter):
     def __init__(self, fmt=remove_seqs(FORMAT), datefmt=None):
-        logging.Formatter.__init__(self, fmt, datefmt)
+        if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 2):
+            logging.Formatter.__init__(self, fmt, datefmt)
+        else:
+            logging.Formatter.__init__(self, fmt, datefmt, '{')
 
     def format(self, record):
         if not hasattr(record, "message"):


### PR DESCRIPTION
`logging.Formatter.__init__()` takes a `style` parameter in Python 3.2 and above, which is supposed to specify the format used for the string passed to the constructor. The default is `'%'`. Here, the `str.format()`/`'{'` style is used, so it makes sense to specify it properly. Omitting this doesn't really cause obvious problems before Python 3.8, but in 3.8 a validation is now automatically run for the string and it will raise an error if it's not in the expected style.

This addresses #812.